### PR TITLE
Feat/add towncrier hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,3 +39,8 @@ repos:
   rev: 0.23.2
   hooks:
     - id: check-github-workflows
+
+# - repo: https://github.com/twisted/towncrier
+#   rev: 22.13.0  # run 'pre-commit autoupdate' to update
+#   hooks:
+#     - id: towncrier-check

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,3 +8,4 @@ This document follows the conventions laid out in [Keep a CHANGELOG](https://kee
 This project uses [*towncrier*](https://towncrier.readthedocs.io/).
 
 <!-- towncrier release notes start -->
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,10 @@
 # CHANGELOG
+
+All notable changes to this project will be documented in this file.This
+project adheres to [Semantic Versioning](https://semver.org/).
+
+This document follows the conventions laid out in [Keep a CHANGELOG](https://keepachangelog.com/en/1.0.0).
+
+This project uses [*towncrier*](https://towncrier.readthedocs.io/).
+
+<!-- towncrier release notes start -->

--- a/changelog.d/1.added.md
+++ b/changelog.d/1.added.md
@@ -1,0 +1,1 @@
+Added a cool feature!

--- a/changelog.d/2.fixed.md
+++ b/changelog.d/2.fixed.md
@@ -1,0 +1,1 @@
+Fixed the cool feature :D

--- a/changelog.d/changelog_template.jinja
+++ b/changelog.d/changelog_template.jinja
@@ -1,0 +1,15 @@
+{% if sections[""] %}
+{% for category, val in definitions.items() if category in sections[""] %}
+
+### {{ definitions[category]['name'] }}
+
+{% for text, values in sections[""][category].items() %}
+- {{ text }} {{ values|join(', ') }}
+{% endfor %}
+
+{% endfor %}
+{% else %}
+No significant changes.
+
+
+{% endif %}

--- a/changelog.d/newsfragments/.gitignore
+++ b/changelog.d/newsfragments/.gitignore
@@ -1,0 +1,1 @@
+'!.gitignore'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,14 +25,15 @@ classifiers = [
 ]
 dependencies = [
     "importlib-metadata >=4.0",
-    "reuse <2",
+    "reuse>=2",
+    "GitPython==3.1.32",
 ]
 
 [project.optional-dependencies]
 tests = [
     "pytest==7.3.0",
     "pytest-cov==4.0.0",
-    "reuse <2",
+    "reuse>=2",
 ]
 doc = [
     "ansys-sphinx-theme==0.10.0",
@@ -76,3 +77,41 @@ addopts = "--cov=ansys.pre_commit_hooks --cov-report term -vv"
 testpaths = [
     "tests",
 ]
+
+[tool.towncrier]
+directory = "changelog.d"
+filename = "CHANGELOG.md"
+start_string = "<!-- towncrier release notes start -->\n"
+template = "changelog.d/changelog_template.jinja"
+title_format = "## [{version}](https://github.com/ansys/pre-commit-hooks/releases/tag/v{version}) - {project_date}"
+issue_format = "`#{issue} <https://github.com/ansys/pre-commit-hooks/issues/{issue}>`_"
+
+    [[tool.towncrier.type]]
+    directory = "security"
+    name = "Security"
+    showcontent = true
+
+    [[tool.towncrier.type]]
+    directory = "removed"
+    name = "Removed"
+    showcontent = true
+
+    [[tool.towncrier.type]]
+    directory = "deprecated"
+    name = "Deprecated"
+    showcontent = true
+
+    [[tool.towncrier.type]]
+    directory = "added"
+    name = "Added"
+    showcontent = true
+
+    [[tool.towncrier.type]]
+    directory = "changed"
+    name = "Changed"
+    showcontent = true
+
+    [[tool.towncrier.type]]
+    directory = "fixed"
+    name = "Fixed"
+    showcontent = true

--- a/src/ansys/pre_commit_hooks/edit_changelog.py
+++ b/src/ansys/pre_commit_hooks/edit_changelog.py
@@ -1,0 +1,58 @@
+"""Use towncrier to determine if fragments are available & merge fragments into changelog."""
+import os
+import subprocess
+
+import git
+
+
+def check_branch():
+    """Get current branch."""
+    git_repo = git.Repo(os.getcwd(), search_parent_directories=True)
+    current_branch = str(git_repo.active_branch)
+
+    root_dir = current_branch.split("/")[0]
+    print(root_dir)
+    # if root_dir != "release":
+    #     run_towncrier_hook()
+    check_towncrier_fragments()
+
+
+def check_towncrier_fragments():
+    """Determine if there are towncrier fragments in the repository."""
+    check = subprocess.run(["towncrier", "check"], stdout=subprocess.PIPE)
+    if "news file changes detected" in check.stdout.decode():
+        print("News file changes detected")
+        towncrier_build()
+
+
+def towncrier_build():
+    """Add fragments to CHANGELOG.md."""
+    # removes the news files with git rm and appends the build news to
+    # file specified in pyproject.toml (CHANGELOG.md) with git add.
+    # The user has to commit this change
+
+    print("run the towncrier command")
+    build = subprocess.run(
+        ["towncrier", "build", "--keep", "--version=0.1.0"], stdout=subprocess.PIPE
+    )
+    # add --keep to keep the news fragments in changelog.d
+    # Remove --version=<number> once the __version__ variable is set up for automatic versioning
+    print(build.stdout.decode())
+
+    # Return 1 since fragments were found and towncrier build was run
+    return 1
+
+
+# When PR is merged, create newsfile on branch
+# towncrier create -c <title of PR> <issuenumber>.<tool.towncrier.type>.md
+#     refer to pyproject.toml for different tool.towncrier.type sections
+# for example: towncrier create -c "Fixed bug issue" 7.fix.md
+
+
+def main():
+    """Update CHANGELOG.md if fragments exist."""
+    check_branch()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
As of July 28th:

Done:
- Check if you are on a release/* branch
    - Currently, I'm testing on this feat/add-towncrier-hook branch instead of release since we don't have a release branch yet
- Determine if there are any [towncrier](https://towncrier.readthedocs.io/en/stable/) fragments available
- Merge fragments into the changelog if they exist and return error code using towncrier build.

To do:
- If the branch is not a release/* branch, we could default to towncrier's pre-commit hook. I think this is also doable.
https://towncrier.readthedocs.io/en/stable/pre-commit.html
    - Have to look into how to only call pre-commit hook under certain circumstances

Eventually closes #9.


** Some of the tests are failing in the workflow because I changed the reuse version in pyproject.toml, but didn't update the code. Once we merge the updated reuse PR into main, we'll have to merge it into this branch to resolve that issue.