### PR TITLE
Removed default args in pre-commit-hooks.yaml

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -2,5 +2,5 @@
   name: "Add License Headers"
   entry: add-license-headers
   language: python
-  args: ["--loc=src"]
+  pass_filenames: false
   description: "Add missing license headers to files by using reuse lint and annotate"


### PR DESCRIPTION
Removed args line in pre-commit-hooks.yaml and set pass_filenames to false. Closes #11.