### PR TITLE
Directory checks & print statement updates

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -18,14 +18,6 @@ concurrency:
 
 jobs:
 
-  code-style:
-    name: "Code style"
-    runs-on: ubuntu-latest
-    steps:
-      - uses: ansys/actions/code-style@v4
-        with:
-          python-version: ${{ env.MAIN_PYTHON_VERSION }}
-
   doc-style:
     name: "Documentation style"
     runs-on: ubuntu-latest
@@ -37,7 +29,6 @@ jobs:
   smoke-tests:
     name: "Build and Smoke tests"
     runs-on: ${{ matrix.os }}
-    needs: [code-style]
     strategy:
       fail-fast: false
       matrix:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This document follows the conventions laid out in [Keep a CHANGELOG](https://kee
 
 ### Added
 
+- Directory checks & print statement updates (#34)
+
 ### Changed
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,31 @@
 # CHANGELOG
+
+This document follows the conventions laid out in [Keep a CHANGELOG](https://keepachangelog.com/en/1.0.0).
+
+## [Unreleased][]
+
+### Added
+
+### Changed
+
+### Fixed
+
+### Dependencies
+
+## [0.1.0](https://github.com/ansys/pre-commit-hooks/releases/tag/v0.1.0) - September 1 2023
+
+### Added
+
+- Create pre-commit hook to add license header to all files (#7)
+- Default args in pre-commit-hooks.yaml (#11)
+- feat: ignore links (temp) (#20)
+
+### Changed
+
+- Update the readme file (#21)
+- Edits to RST and PY files (#28)
+
+### Fixed
+
+- Fix add-license-headers for reuse version >=2 (#10)
+- Fix reuse 2.0 implementation (#17)

--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,6 @@
 Ansys pre-commit hooks
 ======================
-|pyansys| |python| |pypi| |GH-CI| |MIT| |black|
+|pyansys| |python| |pypi| |GH-CI| |MIT| |black| |pre-commit-ci|
 
 .. |pyansys| image:: https://img.shields.io/badge/Py-Ansys-ffc107.svg?logo=data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAIAAACQkWg2AAABDklEQVQ4jWNgoDfg5mD8vE7q/3bpVyskbW0sMRUwofHD7Dh5OBkZGBgW7/3W2tZpa2tLQEOyOzeEsfumlK2tbVpaGj4N6jIs1lpsDAwMJ278sveMY2BgCA0NFRISwqkhyQ1q/Nyd3zg4OBgYGNjZ2ePi4rB5loGBhZnhxTLJ/9ulv26Q4uVk1NXV/f///////69du4Zdg78lx//t0v+3S88rFISInD59GqIH2esIJ8G9O2/XVwhjzpw5EAam1xkkBJn/bJX+v1365hxxuCAfH9+3b9/+////48cPuNehNsS7cDEzMTAwMMzb+Q2u4dOnT2vWrMHu9ZtzxP9vl/69RVpCkBlZ3N7enoDXBwEAAA+YYitOilMVAAAAAElFTkSuQmCC
    :target: https://docs.pyansys.com/
@@ -26,6 +26,9 @@ Ansys pre-commit hooks
    :target: https://github.com/psf/black
    :alt: Black
 
+.. |pre-commit-ci| image:: https://results.pre-commit.ci/badge/github/ansys/pre-commit-hooks/main.svg
+   :target: https://results.pre-commit.ci/latest/github/ansys/pre-commit-hooks/main
+   :alt: pre-commit.ci status
 
 This Ansys repository contains `pre-commit`_ hooks for different purposes.
 Currently, these hooks are available:

--- a/README.rst
+++ b/README.rst
@@ -34,6 +34,20 @@ Currently, these hooks are available:
   `REUSE <https://reuse.software/>`_ . To use this hook, you must
   have ``REUSE`` implemented in your repository.
 
+      1. Copy the .reuse directory from this repository into your repository.
+      2. Ensure your repository has the "src" directory.
+        - If the "src" directory does not exist, specify which directory should
+        be checked for files missing license headers. To do so, add the args line
+        to .pre-commit-config.yaml in your repository:
+
+        - repo: https://github.com/ansys/pre-commit-hooks
+          rev: v0.1.0
+          hooks:
+          - id: add-license-headers 
+              args:
+              - --loc=mydir
+
+        Where mydir is a directory containing files that are checked for license headers. 
 
 How to install
 --------------

--- a/README.rst
+++ b/README.rst
@@ -39,20 +39,20 @@ Currently, these hooks are available:
 
      .. note::
 
-        If the "src" directory does not exist, specify which directory should
+        If the ``src`` directory does not exist, specify which directory should
         be checked for files missing license headers. To do so, add the args line
-        to .pre-commit-config.yaml in your repository:
+        to ``.pre-commit-config.yaml`` in your repository:
 
-     .. code:: yaml
+        .. code:: yaml
 
-        - repo: https://github.com/ansys/pre-commit-hooks
-          rev: v0.1.0
-          hooks:
-          - id: add-license-headers
-              args:
-              - --loc=mydir
+           - repo: https://github.com/ansys/pre-commit-hooks
+             rev: v0.1.0
+             hooks:
+             - id: add-license-headers
+                 args:
+                 - --loc=mydir
 
-     Where mydir is a directory containing files that are checked for license headers.
+        Where ``mydir`` is a directory containing files that are checked for license headers.
 
 How to install
 --------------

--- a/README.rst
+++ b/README.rst
@@ -43,11 +43,11 @@ Currently, these hooks are available:
         - repo: https://github.com/ansys/pre-commit-hooks
           rev: v0.1.0
           hooks:
-          - id: add-license-headers 
+          - id: add-license-headers
               args:
               - --loc=mydir
 
-        Where mydir is a directory containing files that are checked for license headers. 
+        Where mydir is a directory containing files that are checked for license headers.
 
 How to install
 --------------

--- a/README.rst
+++ b/README.rst
@@ -34,11 +34,16 @@ Currently, these hooks are available:
   `REUSE <https://reuse.software/>`_ . To use this hook, you must
   have ``REUSE`` implemented in your repository.
 
-      1. Copy the .reuse directory from this repository into your repository.
-      2. Ensure your repository has the "src" directory.
-        - If the "src" directory does not exist, specify which directory should
+  #. Copy the .reuse directory from this repository into your repository.
+  #. Ensure your repository has the "src" directory.
+
+     .. note::
+
+        If the "src" directory does not exist, specify which directory should
         be checked for files missing license headers. To do so, add the args line
         to .pre-commit-config.yaml in your repository:
+
+     .. code:: yaml
 
         - repo: https://github.com/ansys/pre-commit-hooks
           rev: v0.1.0
@@ -47,7 +52,7 @@ Currently, these hooks are available:
               args:
               - --loc=mydir
 
-        Where mydir is a directory containing files that are checked for license headers.
+     Where mydir is a directory containing files that are checked for license headers.
 
 How to install
 --------------

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -92,12 +92,6 @@ source_suffix = ".rst"
 # The master toctree document.
 master_doc = "index"
 
-# TODO: Once the repo goes public... remove these links
-linkcheck_ignore = [
-    r"https://github.com/ansys/pre-commit-hooks/*",
-    r"https://pypi.org/project/ansys-pre-commit-hooks",
-]
-
 # Configuration for Sphinx autoapi
 autoapi_type = "python"
 autoapi_dirs = ["../../src/ansys/pre_commit_hooks/"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,7 +80,7 @@ show_missing = true
 
 [tool.pytest.ini_options]
 minversion = "7.1"
-addopts = "--cov=ansys.pre_commit_hooks --cov-report term -vv"
+addopts = "--cov=ansys.pre_commit_hooks --cov-report term-missing -vv"
 testpaths = [
     "tests",
 ]

--- a/src/ansys/pre_commit_hooks/add_license_headers.py
+++ b/src/ansys/pre_commit_hooks/add_license_headers.py
@@ -164,7 +164,7 @@ def repo_path():
 
 def check_dir_exists(folder_name) -> bool:
     """
-    Check if the ``.reuse`` or the location directory exists in the root path of the git repo.
+    Check if the ``.reuse`` or the location directory exist in the root path of the git repo.
 
     Parameters
     ----------

--- a/src/ansys/pre_commit_hooks/add_license_headers.py
+++ b/src/ansys/pre_commit_hooks/add_license_headers.py
@@ -123,7 +123,7 @@ def find_files_missing_header():
     parser = argparse.ArgumentParser()
     args = set_lint_args(parser)
 
-    # Check if  exists
+    # Check if required directories exist
     dir_exists = check_dir_exists(args.loc)
     if not dir_exists:
         # Previous check_dir_exists() function returned error because

--- a/tests/test_dependencies.py
+++ b/tests/test_dependencies.py
@@ -3,5 +3,6 @@ import os
 
 def test_template_exists():
     """Test license format file exists."""
-    jinja_file = os.path.join(".", ".reuse", "templates", "ansys.jinja2")
+    ROOT_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    jinja_file = os.path.join(ROOT_DIR, ".reuse", "templates", "ansys.jinja2")
     assert os.path.exists(jinja_file)


### PR DESCRIPTION
- Updated README.rst to provide more details about how to set up your repository with reuse and how to run the hook on directories other than src
- Removed linkcheck_ignore from conf.py since the repo is public
- Added default_dir variable to easily change the default directory the loc argument is given
- Added a check if the default_dir exists, and corresponding instructions if it doesn't exist
- Added tests to check the above changes