### PR TITLE
Update descriptions for add-license-headers in README

### DIFF
--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -47,6 +47,10 @@ Files: .pre-commit-hooks.yaml
 Copyright: 2023 ANSYS, Inc. and/or its affiliates.
 License: MIT
 
+Files: AUTHORS
+Copyright: 2023 ANSYS, Inc. and/or its affiliates.
+License: MIT
+
 Files: CHANGELOG.md
 Copyright: 2023 ANSYS, Inc. and/or its affiliates.
 License: MIT
@@ -56,6 +60,10 @@ Copyright: 2023 ANSYS, Inc. and/or its affiliates.
 License: MIT
 
 Files: CONTRIBUTING.md
+Copyright: 2023 ANSYS, Inc. and/or its affiliates.
+License: MIT
+
+Files: CONTRIBUTORS.md
 Copyright: 2023 ANSYS, Inc. and/or its affiliates.
 License: MIT
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,18 @@
 
 This document follows the conventions laid out in [Keep a CHANGELOG](https://keepachangelog.com/en/1.0.0).
 
+## [Unreleased]()
+
+### Changed
+
+- Update descriptions for add-license-headers in README (#40)
+
 ## [0.1.2](https://github.com/ansys/pre-commit-hooks/releases/tag/v0.1.2) - September 5, 2023
 
 ### Dependencies
 
 - [pre-commit.ci] pre-commit autoupdate [#39](https://github.com/ansys/pre-commit-hooks/pull/39)
+
 ## [0.1.1](https://github.com/ansys/pre-commit-hooks/releases/tag/v0.1.1) - September 4, 2023
 
 ### Added

--- a/README.rst
+++ b/README.rst
@@ -41,13 +41,13 @@ Currently, these hooks are available:
 
      .. note::
 
-        Configure .reuse/dep5 to match the file structure within your repository. 
+        Configure .reuse/dep5 to match the file structure within your repository.
         The dep5 file contains files & directories that should not be given license headers.
 
         .reuse/templates/ansys.jinja2 contains the template for the license headers that are
         added to the files. If the content of the MIT license changes, replace the lines between
         the if statements in the following code block:
-        
+
         .. code:: jinja2
 
            {% if "MIT" in spdx_expressions %}

--- a/README.rst
+++ b/README.rst
@@ -48,7 +48,7 @@ Currently, these hooks are available:
         added to the files. If the content of the MIT license changes, replace the lines between
         the if statements in the following code block:
 
-        .. code:: jinja2
+        .. code:: jinja
 
            {% if "MIT" in spdx_expressions %}
            ...

--- a/README.rst
+++ b/README.rst
@@ -52,8 +52,8 @@ Currently, these hooks are available:
              rev: v0.1.0
              hooks:
              - id: add-license-headers
-                 args:
-                 - --loc=mydir
+               args:
+               - --loc=mydir
 
         Where ``mydir`` is a directory containing files that are checked for license headers.
 

--- a/README.rst
+++ b/README.rst
@@ -38,6 +38,22 @@ Currently, these hooks are available:
   have ``REUSE`` implemented in your repository.
 
   #. Copy the .reuse directory from this repository into your repository.
+
+     .. note::
+
+        Configure .reuse/dep5 to match the file structure within your repository. 
+        The dep5 file contains files & directories that should not be given license headers.
+
+        .reuse/templates/ansys.jinja2 contains the template for the license headers that are
+        added to the files. If the content of the MIT license changes, replace the lines between
+        the if statements in the following code block:
+        
+        .. code:: jinja2
+
+           {% if "MIT" in spdx_expressions %}
+           ...
+           {% endif %}
+
   #. Ensure your repository has the "src" directory.
 
      .. note::


### PR DESCRIPTION
Previous add-license-headers example caused syntax error in the .pre-commit-config file if you specified the loc arg. Also, added descriptions of the files in the .reuse directory, and added a couple files missing from our dep5 file.