### PR TITLE
Create custom flags for add-license-header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ This document follows the conventions laid out in [Keep a CHANGELOG](https://kee
 
 ## Added
 
-- Allow reuse to run on multiple directories (#43)
+- Create custom flags for add-license-header (#44)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This document follows the conventions laid out in [Keep a CHANGELOG](https://kee
 
 ## [Unreleased]()
 
+## Added
+
+- Allow reuse to run on multiple directories (#43)
+
 ### Changed
 
 - Update descriptions for add-license-headers in README (#40)

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023 ANSYS, Inc. and/or its affiliates.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.rst
+++ b/README.rst
@@ -68,15 +68,22 @@ Currently, these hooks are available:
              rev: v0.1.0
              hooks:
              - id: add-license-headers
-               args: ["--loc", "dir1,dir2"]
+               args: ["--loc", "dir1,dir2", "--custom_copyright", "custom copyright phrase", "--custom_template", "template_name", "--custom_license", "license_name"]
 
-        Where ``dir1`` and ``dir2`` are directories containing files that are checked for license headers.
+        ``dir1`` and ``dir2`` are directories containing files that are checked for license headers.
+        ``custom copyright phrase`` is the copyright line you want to include in the license header.
+        ``template_name`` is the name of the .jinja2 file located in .reuse/templates/
+        ``license_name`` is the name of the license being used. For example, MIT, ECL-1.0, etc. To view a list of licenses that are supported by ``REUSE``, see https://github.com/spdx/license-list-data/tree/main/text
+
         ``args`` can also be formatted as follows:
 
         .. code:: yaml
 
                args:
                - --loc=dir1,dir2
+               - --custom_copyright=custom copyright phrase
+               - --custom_template=template_name
+               - --custom_license=license_name
 
 How to install
 --------------

--- a/README.rst
+++ b/README.rst
@@ -68,10 +68,18 @@ Currently, these hooks are available:
              rev: v0.1.0
              hooks:
              - id: add-license-headers
-               args:
-               - --loc=mydir
+               args: ["--loc", "dir1,dir2"]
 
-        Where ``mydir`` is a directory containing files that are checked for license headers.
+         or
+
+         .. code:: yaml
+
+           ...
+             - id: add-license-headers
+               args:
+               - --loc=dir1,dir2
+
+        Where ``dir1`` and ``dir2`` are directories containing files that are checked for license headers.
 
 How to install
 --------------

--- a/README.rst
+++ b/README.rst
@@ -70,16 +70,13 @@ Currently, these hooks are available:
              - id: add-license-headers
                args: ["--loc", "dir1,dir2"]
 
-         or
+        Where ``dir1`` and ``dir2`` are directories containing files that are checked for license headers.
+        ``args`` can also be formatted as follows:
 
-         .. code:: yaml
+        .. code:: yaml
 
-           ...
-             - id: add-license-headers
                args:
                - --loc=dir1,dir2
-
-        Where ``dir1`` and ``dir2`` are directories containing files that are checked for license headers.
 
 How to install
 --------------

--- a/README.rst
+++ b/README.rst
@@ -70,10 +70,15 @@ Currently, these hooks are available:
              - id: add-license-headers
                args: ["--loc", "dir1,dir2", "--custom_copyright", "custom copyright phrase", "--custom_template", "template_name", "--custom_license", "license_name"]
 
-        ``dir1`` and ``dir2`` are directories containing files that are checked for license headers.
-        ``custom copyright phrase`` is the copyright line you want to include in the license header.
-        ``template_name`` is the name of the .jinja2 file located in .reuse/templates/
-        ``license_name`` is the name of the license being used. For example, MIT, ECL-1.0, etc. To view a list of licenses that are supported by ``REUSE``, see https://github.com/spdx/license-list-data/tree/main/text
+        - ``dir1`` and ``dir2`` are directories containing files that are checked for license
+          headers. By default, it looks for the ``src`` folder.
+        - ``custom copyright phrase`` is the copyright line you want to include in the license
+          header. By default, it uses ``"ANSYS, Inc. and/or its affiliates."``.
+        - ``template_name`` is the name of the .jinja2 file located in ``.reuse/templates/``.
+          By default, it uses ``ansys``.
+        - ``license_name`` is the name of the license being used. For example, MIT, ECL-1.0, etc.
+          To view a list of licenses that are supported by ``REUSE``, see
+          https://github.com/spdx/license-list-data/tree/main/text. By default it uses ``MIT``.
 
         ``args`` can also be formatted as follows:
 

--- a/tests/test_reuse.py
+++ b/tests/test_reuse.py
@@ -1,5 +1,6 @@
 import argparse
 import os
+import shutil
 import sys
 
 import git
@@ -148,6 +149,43 @@ def test_default_dir_dne(tmp_path: pytest.TempPathFactory):
         assert result == 2
     finally:
         os.chdir(test_dir)
+
+
+def test_custom_args(tmp_path: pytest.TempPathFactory):
+    """Test custom arguments for loc, copyright, template, and license."""
+    # Initialize tmp_path as a git repository
+    git.Repo.init(tmp_path)
+
+    dirs = ["dir1", "dir2"]
+    template_name = "test_template.jinja2"
+    template_path = os.path.join(os.getcwd(), "tests", template_name)
+    reuse_dir = os.path.join(tmp_path, ".reuse", "templates")
+
+    # Create .reuse directory and copy template file to it
+    os.makedirs(reuse_dir)
+    shutil.copyfile(f"{template_path}", f"{reuse_dir}/{template_name}")
+
+    # Create directories & files to test
+    for dir in dirs:
+        dir_path = os.path.join(tmp_path, dir)
+        # Create src code directory
+        os.mkdir(dir_path)
+        os.chdir(dir_path)
+        # Add temporary file to directory
+        create_test_file(dir_path)
+        os.chdir(tmp_path)
+
+    # Pass in custom arguments
+    sys.argv[1:] = [
+        f"--loc={dirs[0]},{dirs[1]}",
+        '--custom_copyright="Super cool copyright"',
+        "--custom_template=test_template",
+        "--custom_license=ECL-1.0",
+    ]
+    res = hook.main()
+
+    # Assert main runs successfully with custom arguments
+    assert res == 1
 
 
 def test_main_passes():

--- a/tests/test_template.jinja2
+++ b/tests/test_template.jinja2
@@ -1,0 +1,31 @@
+The Educational Community License
+
+This Educational Community License (the "License") applies to any original work of authorship (the "Original Work") whose owner (the "Licensor") has placed the following notice immediately following the copyright notice for the Original Work:
+
+{% for copyright_line in copyright_lines %}
+{{ copyright_line }}
+{% endfor %}
+{% for expression in spdx_expressions %}
+SPDX-License-Identifier: {{ expression }}
+{% endfor %}
+
+Licensed under the Educational Community License version 1.0
+
+{% if "ECL-1.0" in spdx_expressions %}
+
+This Original Work, including software, source code, documents, or other related items, is being provided by the copyright holder(s) subject to the terms of the Educational Community License. By obtaining, using and/or copying this Original Work, you agree that you have read, understand, and will comply with the following terms and conditions of the Educational Community License:
+
+Permission to use, copy, modify, merge, publish, distribute, and sublicense this Original Work and its documentation, with or without modification, for any purpose, and without fee or royalty to the copyright holder(s) is hereby granted, provided that you include the following on ALL copies of the Original Work or portions thereof, including modifications or derivatives, that you make:
+
+     The full text of the Educational Community License in a location viewable to users of the redistributed or derivative work.
+
+     Any pre-existing intellectual property disclaimers, notices, or terms and conditions.
+
+     Notice of any changes or modifications to the Original Work, including the date the changes were made.
+
+     Any modifications of the Original Work must be distributed in such a manner as to avoid any confusion with the Original Work of the copyright holders.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+The name and trademarks of copyright holder(s) may NOT be used in advertising or publicity pertaining to the Original or Derivative Works without specific, written prior permission. Title to copyright in the Original Work and any associated documentation will at all times remain with the copyright holders.
+{% endif %}


### PR DESCRIPTION
Created custom flags for loc (allow 1+ locations to be listed), license (license other than MIT), copyright (unique copyright line other than Ansys), and template (allow different template name, name.jinja2). Also created test to test the custom flag implementation. Updated README as well. This closes #41 and #42.