### PR TITLE
feat: remove "custom" prefix from hook arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This document follows the conventions laid out in [Keep a CHANGELOG](https://kee
 
 ### Changed
 
+- feat: remove "custom" prefix from hook arguments [#49](https://github.com/ansys/pre-commit-hooks/pull/49)
+
 ### Dependencies
 
 ### Fixed
@@ -16,11 +18,11 @@ This document follows the conventions laid out in [Keep a CHANGELOG](https://kee
 
 ### Added
 
-- Create custom flags for add-license-header (#44)
+- Create custom flags for add-license-header [#44](https://github.com/ansys/pre-commit-hooks/pull/44)
 
 ### Changed
 
-- Update descriptions for add-license-headers in README (#40)
+- Update descriptions for add-license-headers in README [#40](https://github.com/ansys/pre-commit-hooks/pull/40)
 
 ## [0.1.2](https://github.com/ansys/pre-commit-hooks/releases/tag/v0.1.2) - September 5, 2023
 
@@ -45,16 +47,16 @@ This document follows the conventions laid out in [Keep a CHANGELOG](https://kee
 
 ### Added
 
-- Create pre-commit hook to add license header to all files (#7)
-- Default args in pre-commit-hooks.yaml (#11)
-- feat: ignore links (temp) (#20)
+- Create pre-commit hook to add license header to all files [#7](https://github.com/ansys/pre-commit-hooks/pull/7)
+- Default args in pre-commit-hooks.yaml [#11](https://github.com/ansys/pre-commit-hooks/pull/11)
+- feat: ignore links (temp) [#20](https://github.com/ansys/pre-commit-hooks/pull/20)
 
 ### Changed
 
-- Update the readme file (#21)
-- Edits to RST and PY files (#28)
+- Update the readme file [#21](https://github.com/ansys/pre-commit-hooks/pull/21)
+- Edits to RST and PY files [#28](https://github.com/ansys/pre-commit-hooks/pull/28)
 
 ### Fixed
 
-- Fix add-license-headers for reuse version >=2 (#10)
-- Fix reuse 2.0 implementation (#17)
+- Fix add-license-headers for reuse version >=2 [#10](https://github.com/ansys/pre-commit-hooks/pull/10)
+- Fix reuse 2.0 implementation [#17](https://github.com/ansys/pre-commit-hooks/pull/17)

--- a/README.rst
+++ b/README.rst
@@ -68,7 +68,7 @@ Currently, these hooks are available:
              rev: v0.1.0
              hooks:
              - id: add-license-headers
-               args: ["--loc", "dir1,dir2", "--copyright", "custom_copyright_phrase", "--template", "template_name", "--license", "license_name"]
+               args: ["--loc", "dir1,dir2", "--copyright-spdx", "custom_copyright_phrase", "--template", "template_name", "--license", "license_name"]
 
         - ``dir1`` and ``dir2`` are directories containing files that are checked for license
           headers. By default, it looks for the ``src`` folder.
@@ -86,7 +86,7 @@ Currently, these hooks are available:
 
                args:
                - --loc=dir1,dir2
-               - --copyright=custom_copyright_phrase
+               - --copyright-spdx=custom_copyright_phrase
                - --template=template_name
                - --license=license_name
 

--- a/README.rst
+++ b/README.rst
@@ -68,7 +68,7 @@ Currently, these hooks are available:
              rev: v0.1.0
              hooks:
              - id: add-license-headers
-               args: ["--loc", "dir1,dir2", "--custom_copyright", "custom copyright phrase", "--custom_template", "template_name", "--custom_license", "license_name"]
+               args: ["--loc", "dir1,dir2", "--copyright", "custom copyright phrase", "--template", "template_name", "--license", "license_name"]
 
         - ``dir1`` and ``dir2`` are directories containing files that are checked for license
           headers. By default, it looks for the ``src`` folder.
@@ -86,9 +86,9 @@ Currently, these hooks are available:
 
                args:
                - --loc=dir1,dir2
-               - --custom_copyright=custom copyright phrase
-               - --custom_template=template_name
-               - --custom_license=license_name
+               - --copyright=custom copyright phrase
+               - --template=template_name
+               - --license=license_name
 
 How to install
 --------------

--- a/README.rst
+++ b/README.rst
@@ -68,11 +68,11 @@ Currently, these hooks are available:
              rev: v0.1.0
              hooks:
              - id: add-license-headers
-               args: ["--loc", "dir1,dir2", "--copyright", "custom copyright phrase", "--template", "template_name", "--license", "license_name"]
+               args: ["--loc", "dir1,dir2", "--copyright", "custom_copyright_phrase", "--template", "template_name", "--license", "license_name"]
 
         - ``dir1`` and ``dir2`` are directories containing files that are checked for license
           headers. By default, it looks for the ``src`` folder.
-        - ``custom copyright phrase`` is the copyright line you want to include in the license
+        - ``custom_copyright_phrase`` is the copyright line you want to include in the license
           header. By default, it uses ``"ANSYS, Inc. and/or its affiliates."``.
         - ``template_name`` is the name of the .jinja2 file located in ``.reuse/templates/``.
           By default, it uses ``ansys``.
@@ -86,7 +86,7 @@ Currently, these hooks are available:
 
                args:
                - --loc=dir1,dir2
-               - --copyright=custom copyright phrase
+               - --copyright=custom_copyright_phrase
                - --template=template_name
                - --license=license_name
 

--- a/src/ansys/pre_commit_hooks/add_license_headers.py
+++ b/src/ansys/pre_commit_hooks/add_license_headers.py
@@ -65,7 +65,7 @@ def set_lint_args(parser):
         default=DEFAULT_SOURCE_CODE_DIRECTORY,
     )
     parser.add_argument(
-        "--copyright",
+        "--copyright-spdx",
         type=str,
         help="Default copyright line for license headers.",
         default=DEFAULT_COPYRIGHT,

--- a/src/ansys/pre_commit_hooks/add_license_headers.py
+++ b/src/ansys/pre_commit_hooks/add_license_headers.py
@@ -65,19 +65,19 @@ def set_lint_args(parser):
         default=DEFAULT_SOURCE_CODE_DIRECTORY,
     )
     parser.add_argument(
-        "--custom_copyright",
+        "--copyright",
         type=str,
         help="Default copyright line for license headers.",
         default=DEFAULT_COPYRIGHT,
     )
     parser.add_argument(
-        "--custom_template",
+        "--template",
         type=str,
         help="Default template to use for license headers.",
         default=DEFAULT_TEMPLATE,
     )
     parser.add_argument(
-        "--custom_license",
+        "--license",
         type=str,
         help="Default license for headers.",
         default=DEFAULT_LICENSE,
@@ -254,9 +254,9 @@ def find_files_missing_header():
 
     # Get custom specified directories, copyright, template, and/or license
     dirs = args.loc.split(",")
-    copyright = args.custom_copyright
-    template = args.custom_template
-    license = args.custom_license
+    copyright = args.copyright
+    template = args.template
+    license = args.license
     changed_headers = False
 
     # Get current year for license file

--- a/tests/test_reuse.py
+++ b/tests/test_reuse.py
@@ -178,9 +178,9 @@ def test_custom_args(tmp_path: pytest.TempPathFactory):
     # Pass in custom arguments
     sys.argv[1:] = [
         f"--loc={dirs[0]},{dirs[1]}",
-        '--custom_copyright="Super cool copyright"',
-        "--custom_template=test_template",
-        "--custom_license=ECL-1.0",
+        '--copyright="Super cool copyright"',
+        "--template=test_template",
+        "--license=ECL-1.0",
     ]
     res = hook.main()
 

--- a/tests/test_reuse.py
+++ b/tests/test_reuse.py
@@ -178,7 +178,7 @@ def test_custom_args(tmp_path: pytest.TempPathFactory):
     # Pass in custom arguments
     sys.argv[1:] = [
         f"--loc={dirs[0]},{dirs[1]}",
-        '--copyright="Super cool copyright"',
+        '--copyright-spdx="Super cool copyright"',
         "--template=test_template",
         "--license=ECL-1.0",
     ]


### PR DESCRIPTION
We shouldn't be calling the arguments with a "custom" prefix. If users are defining their own arguments that's because they want to use their own values. So, one can already infer that it is "custom".