### PR TITLE
Removed loc argument & passed in committed files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This document follows the conventions laid out in [Keep a CHANGELOG](https://kee
 
 ### Changed
 
+- Removed loc argument & passed in committed files (#57)
+
 ### Dependencies
 
 ### Fixed

--- a/README.rst
+++ b/README.rst
@@ -113,7 +113,7 @@ Currently, these hooks are available:
 
         #. In .reuse/dep5
 
-          .. code:: dep5
+          .. code:: debcontrol
 
            Files: path/to/file1.py
            Copyright: 2023 ANSYS, Inc. and/or its affiliates.

--- a/README.rst
+++ b/README.rst
@@ -84,6 +84,50 @@ Currently, these hooks are available:
          To view a list of licenses that are supported by ``REUSE``, see
          https://github.com/spdx/license-list-data/tree/main/text. By default it uses ``MIT``.
 
+  #. Ignore specific files or file types
+
+     .. note::
+
+        There are two different ways to ignore specific files or file types:
+
+        #. In .pre-commit-config.yaml
+
+          .. code:: yaml
+
+           - repo: https://github.com/ansys/pre-commit-hooks
+             rev: v0.1.3
+             hooks:
+             - id: add-license-headers
+               exclude: |
+                   (?x)^(
+                       path/to/file1.py |
+                       path/to/.*\.md |
+                       path/to/.*\.(ts|cpp) |
+                   )$
+
+          .. note ::
+
+           - ``path/to/file1.py`` excludes the stated file.
+           - ``path/to/.*\.md`` exlcudes all .md files within the ``path/to`` directory.
+           - ``path/to/.*\.(ts|cpp)`` excludes all .ts and .cpp files within the ``path/to`` directory.
+
+        #. In .reuse/dep5
+
+          .. code:: dep5
+
+           Files: path/to/file1.py
+           Copyright: 2023 ANSYS, Inc. and/or its affiliates.
+           License: MIT
+
+           Files: path/to/*.py
+           Copyright: 2023 ANSYS, Inc. and/or its affiliates.
+           License: MIT
+
+          .. note::
+           - ``path/to/file1.py`` excludes the stated file.
+           - ``path/to/*.py`` excludes all .py files in the ``path/to`` directory.
+
+
 How to install
 --------------
 

--- a/README.rst
+++ b/README.rst
@@ -43,6 +43,7 @@ Currently, these hooks are available:
 
         Configure .reuse/dep5 to match the file structure within your repository.
         The dep5 file contains files & directories that should not be given license headers.
+        Ensure all files and directories you want to ignore are in this file.
 
         .reuse/templates/ansys.jinja2 contains the template for the license headers that are
         added to the files. If the content of the MIT license changes, replace the lines between
@@ -54,41 +55,34 @@ Currently, these hooks are available:
            ...
            {% endif %}
 
-  #. Ensure your repository has the "src" directory.
+  #. Set custom arguments for the pre-commit hook if necessary.
+
+     .. code:: yaml
+
+      - repo: https://github.com/ansys/pre-commit-hooks
+        rev: v0.1.4
+        hooks:
+        - id: add-license-headers
+          args: ["--custom_copyright", "custom copyright phrase", "--custom_template", "template_name", "--custom_license", "license_name"]
 
      .. note::
 
-        If the ``src`` directory does not exist, specify which directory should
-        be checked for files missing license headers. To do so, add the args line
-        to ``.pre-commit-config.yaml`` in your repository:
+      - ``custom copyright phrase`` is the copyright line you want to include in the license
+         header. By default, it uses ``"ANSYS, Inc. and/or its affiliates."``.
+      - ``template_name`` is the name of the .jinja2 file located in ``.reuse/templates/``.
+         By default, it uses ``ansys``.
+      - ``license_name`` is the name of the license being used. For example, MIT, ECL-1.0, etc.
+         To view a list of licenses that are supported by ``REUSE``, see
+         https://github.com/spdx/license-list-data/tree/main/text. By default it uses ``MIT``.
 
-        .. code:: yaml
+      ``args`` can also be formatted as follows:
 
-           - repo: https://github.com/ansys/pre-commit-hooks
-             rev: v0.1.0
-             hooks:
-             - id: add-license-headers
-               args: ["--loc", "dir1,dir2", "--custom_copyright", "custom copyright phrase", "--custom_template", "template_name", "--custom_license", "license_name"]
+     .. code:: yaml
 
-        - ``dir1`` and ``dir2`` are directories containing files that are checked for license
-          headers. By default, it looks for the ``src`` folder.
-        - ``custom copyright phrase`` is the copyright line you want to include in the license
-          header. By default, it uses ``"ANSYS, Inc. and/or its affiliates."``.
-        - ``template_name`` is the name of the .jinja2 file located in ``.reuse/templates/``.
-          By default, it uses ``ansys``.
-        - ``license_name`` is the name of the license being used. For example, MIT, ECL-1.0, etc.
-          To view a list of licenses that are supported by ``REUSE``, see
-          https://github.com/spdx/license-list-data/tree/main/text. By default it uses ``MIT``.
-
-        ``args`` can also be formatted as follows:
-
-        .. code:: yaml
-
-               args:
-               - --loc=dir1,dir2
-               - --custom_copyright=custom copyright phrase
-               - --custom_template=template_name
-               - --custom_license=license_name
+      args:
+      - --custom_copyright=custom copyright phrase
+      - --custom_template=template_name
+      - --custom_license=license_name
 
 How to install
 --------------

--- a/README.rst
+++ b/README.rst
@@ -60,22 +60,12 @@ Currently, these hooks are available:
      .. code:: yaml
 
       - repo: https://github.com/ansys/pre-commit-hooks
-        rev: v0.1.4
+        rev: v0.1.3
         hooks:
         - id: add-license-headers
           args: ["--custom_copyright", "custom copyright phrase", "--custom_template", "template_name", "--custom_license", "license_name"]
 
-     .. note::
-
-      - ``custom copyright phrase`` is the copyright line you want to include in the license
-         header. By default, it uses ``"ANSYS, Inc. and/or its affiliates."``.
-      - ``template_name`` is the name of the .jinja2 file located in ``.reuse/templates/``.
-         By default, it uses ``ansys``.
-      - ``license_name`` is the name of the license being used. For example, MIT, ECL-1.0, etc.
-         To view a list of licenses that are supported by ``REUSE``, see
-         https://github.com/spdx/license-list-data/tree/main/text. By default it uses ``MIT``.
-
-      ``args`` can also be formatted as follows:
+     ``args`` can also be formatted as follows:
 
      .. code:: yaml
 
@@ -83,6 +73,16 @@ Currently, these hooks are available:
       - --custom_copyright=custom copyright phrase
       - --custom_template=template_name
       - --custom_license=license_name
+
+     .. note::
+
+      #. ``custom copyright phrase`` is the copyright line you want to include in the license
+         header. By default, it uses ``"ANSYS, Inc. and/or its affiliates."``.
+      #. ``template_name`` is the name of the .jinja2 file located in ``.reuse/templates/``.
+         By default, it uses ``ansys``.
+      #. ``license_name`` is the name of the license being used. For example, MIT, ECL-1.0, etc.
+         To view a list of licenses that are supported by ``REUSE``, see
+         https://github.com/spdx/license-list-data/tree/main/text. By default it uses ``MIT``.
 
 How to install
 --------------

--- a/src/ansys/pre_commit_hooks/add_license_headers.py
+++ b/src/ansys/pre_commit_hooks/add_license_headers.py
@@ -204,33 +204,27 @@ def find_files_missing_header():
     proj = project.Project(git_root)
     missing_headers = list(list_noncompliant_files(args, proj))
 
-    def check_exists(changed_headers, i, j):
+    def check_exists(changed_headers, i):
         """Check if the committed file is missing its header."""
-        if i < len(files) and j < len(missing_headers):
-            # If the committed file is the file in missing_headers
-            if files[i] == missing_headers[j]:
+        if i < len(files):
+            # If the committed file is in missing_headers
+            if files[i] in missing_headers:
                 changed_headers = 1
                 # Run REUSE on the file
                 args = set_header_args(parser, year, files[i], copyright, template)
                 args.license = [license]
                 header.run(args, proj)
 
-                # Compare the committed file to the next file in missing_headers
-                return check_exists(changed_headers, i + 1, 0)
+                # Check if the next file is in missing_headers
+                return check_exists(changed_headers, i + 1)
             else:
-                # If file[i] has not been found in missing_headers,
-                # move to the next committed file (file[i+1]) and
-                # reset the count for missing_headers
-                if (j + 1) >= len(missing_headers):
-                    return check_exists(changed_headers, i + 1, 0)
-                else:
-                    return check_exists(changed_headers, i, j + 1)
+                return check_exists(changed_headers, i + 1)
 
         return changed_headers
 
     # Returns 1 if REUSE changes noncompliant files
     # Returns 0 if all files are compliant
-    return check_exists(changed_headers, 0, 0)
+    return check_exists(changed_headers, 0)
 
 
 def main():

--- a/src/ansys/pre_commit_hooks/add_license_headers.py
+++ b/src/ansys/pre_commit_hooks/add_license_headers.py
@@ -153,7 +153,6 @@ def set_header_args(parser, year, file_path, copyright, template):
     args.template = template
     args.skip_unrecognised = True
     args.parser = parser
-    args.recursive = True
 
     return args
 
@@ -206,26 +205,26 @@ def find_files_missing_header():
     missing_headers = list(list_noncompliant_files(args, proj))
 
     def check_exists(changed_headers, i, j):
-        """Check if the committed file is one that is missing its header."""
+        """Check if the committed file is missing its header."""
         if i < len(files) and j < len(missing_headers):
             # If the committed file is the file in missing_headers
             if files[i] == missing_headers[j]:
                 changed_headers = 1
                 # Run REUSE on the file
-                args = set_header_args(parser, year, missing_headers[j], copyright, template)
+                args = set_header_args(parser, year, files[i], copyright, template)
                 args.license = [license]
                 header.run(args, proj)
 
                 # Compare the committed file to the next file in missing_headers
-                check_exists(changed_headers, i + 1, 0)
+                return check_exists(changed_headers, i + 1, 0)
             else:
                 # If file[i] has not been found in missing_headers,
                 # move to the next committed file (file[i+1]) and
                 # reset the count for missing_headers
                 if (j + 1) >= len(missing_headers):
-                    check_exists(changed_headers, i + 1, 0)
+                    return check_exists(changed_headers, i + 1, 0)
                 else:
-                    check_exists(changed_headers, i, j + 1)
+                    return check_exists(changed_headers, i, j + 1)
 
         return changed_headers
 

--- a/tests/test_reuse.py
+++ b/tests/test_reuse.py
@@ -1,54 +1,16 @@
-import argparse
 import os
 import shutil
 import sys
 
 import git
 import pytest
-from reuse import project
 
 import ansys.pre_commit_hooks.add_license_headers as hook
 
-ROOT_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
-
-def test_argparse_passes():
-    """Test argparse passes given loc."""
-    sys.argv[1:] = [f"--loc=./"]
-    parser = argparse.ArgumentParser()
-    args = hook.set_lint_args(parser)
-
-    # Assert loc argument is same as set above
-    assert args.loc == "./"
-
-
-def test_argparse_default():
-    """Test argparse returns default if loc argument is not provided."""
-    sys.argv[1:] = []
-    parser = argparse.ArgumentParser()
-
-    args = hook.set_lint_args(parser)
-
-    # Assert error is thrown for empty loc argument
-    assert args.loc == "src"
-
-
-def test_all_files_compliant(tmp_path: pytest.TempPathFactory):
-    """Test no noncompliant files are found."""
-    sys.argv[1:] = [rf"--loc={tmp_path}"]
-    parser = argparse.ArgumentParser()
-    args = hook.set_lint_args(parser)
-    proj = project.Project(rf"{args.loc}")
-
-    missing_headers = hook.list_noncompliant_files(args, proj)
-
-    # Assert all files are compliant
-    assert len(missing_headers) == 0
-
-
-def create_test_file(tmp_path):
+def create_test_file(tmp_path, file_name):
     """Create temporary file for reuse testing."""
-    test_file = os.path.join(tmp_path, "test.py")
+    test_file = os.path.join(tmp_path, file_name)
 
     # Create test file with a random message
     with open(test_file, "w") as f:
@@ -58,126 +20,45 @@ def create_test_file(tmp_path):
     return test_file
 
 
-def test_noncompliant_files_found(tmp_path: pytest.TempPathFactory):
-    """Test noncompliant file is found."""
-    test_file = create_test_file(tmp_path)
-    sys.argv[1:] = [rf"--loc={tmp_path}"]
-    parser = argparse.ArgumentParser()
-    args = hook.set_lint_args(parser)
-    proj = project.Project(rf"{args.loc}")
-
-    missing_headers = hook.list_noncompliant_files(args, proj)
-
-    # Assert noncompliant file is found
-    assert missing_headers != []
-
-    # Remove test file from git repo
-    os.remove(test_file)
-
-
-def test_find_files_missing_header_passes(tmp_path: pytest.TempPathFactory):
-    """Test no noncompliant files are found."""
-    sys.argv[1:] = [rf"--loc={tmp_path}"]
-    result = hook.find_files_missing_header()
-
-    # Assert all files are compliant
-    assert result == 0
-
-
-def test_find_files_missing_header_fails(tmp_path: pytest.TempPathFactory):
-    """Test noncompliant file is found."""
-    sys.argv[1:] = [rf"--loc={tmp_path}"]
-    # Create noncompliant file in tmp_path
-    test_file = create_test_file(tmp_path)
-    result = hook.find_files_missing_header()
-
-    # Assert noncompliant file is found
-    assert result == 1
-
-    # Remove test file from git repo
-    os.remove(test_file)
-
-
-def test_reuse_dir_dne(tmp_path: pytest.TempPathFactory):
-    """Test reuse directory does not exist."""
-    sys.argv[1:] = [rf"--loc={tmp_path}"]
-    # Create noncompliant file in tmp_path
-    test_file = create_test_file(tmp_path)
-
-    # Rename .reuse to invalid name
-    git_repo = git.Repo(os.getcwd(), search_parent_directories=True)
-    git_root = git_repo.git.rev_parse("--show-toplevel")
-    os.rename(os.path.join(git_root, ".reuse"), os.path.join(git_root, "invalid_reuse"))
-
-    store_err = None
-    try:
-        result = hook.find_files_missing_header()
-
-        # Assert .reuse directory does not exist
-        assert result == 2
-
-    except Exception as err:
-        store_err = err
-        pass
-
-    # Restore original environment
-    os.rename(os.path.join(git_root, "invalid_reuse"), os.path.join(git_root, ".reuse"))
-    os.remove(test_file)
-
-    if store_err:
-        raise store_err
-
-
-def test_default_dir_dne(tmp_path: pytest.TempPathFactory):
-    """Test default directory does not exist."""
-    test_dir = os.getcwd()
-    os.chdir(tmp_path)
-
-    try:
-        # Initialize tmp_path as a git repository
-        git.Repo.init(tmp_path)
-
-        # Create ".reuse" directory
-        os.mkdir(os.path.join(tmp_path, ".reuse"))
-
-        # Check if src directory exists
-        default_dir = "src"
-        sys.argv[1:] = [rf"--loc={default_dir}"]
-        result = hook.find_files_missing_header()
-
-        # Assert src directory was not found in the tmp_path directory
-        assert result == 2
-    finally:
-        os.chdir(test_dir)
-
-
-def test_custom_args(tmp_path: pytest.TempPathFactory):
-    """Test custom arguments for loc, copyright, template, and license."""
-    # Initialize tmp_path as a git repository
-    git.Repo.init(tmp_path)
-
-    dirs = ["dir1", "dir2"]
-    template_name = "test_template.jinja2"
-    template_path = os.path.join(os.getcwd(), "tests", template_name)
+def init_git_repo(tmp_path, template_path, template_name):
+    """Initialize git repository and add the .reuse directory & template."""
     reuse_dir = os.path.join(tmp_path, ".reuse", "templates")
 
     # Create .reuse directory and copy template file to it
     os.makedirs(reuse_dir)
     shutil.copyfile(f"{template_path}", f"{reuse_dir}/{template_name}")
 
-    # Create directories & files to test
-    for dir in dirs:
-        dir_path = os.path.join(tmp_path, dir)
-        # Create src code directory
-        os.mkdir(dir_path)
-        os.chdir(dir_path)
-        # Add temporary file to directory
-        create_test_file(dir_path)
-        os.chdir(tmp_path)
+    # Initialize tmp_path as a git repository
+    git.Repo.init(tmp_path)
+    repo = git.Repo(tmp_path)
+    repo.index.commit("initialized git repo for tmp_path")
+
+    return repo
+
+
+def test_custom_args(tmp_path: pytest.TempPathFactory):
+    """Test custom arguments for loc, copyright, template, and license."""
+    # Save current working directory
+    current_work_dir = os.getcwd()
+
+    template_name = "test_template.jinja2"
+    template_path = os.path.join(os.getcwd(), "tests", template_name)
+
+    # Change dir to tmp_path
+    os.chdir(tmp_path)
+
+    # Set up git repository in tmp_path
+    repo = init_git_repo(tmp_path, template_path, template_name)
+
+    # Create a test file in tmp_path
+    create_test_file(tmp_path, "test.py")
+
+    # Stage test.py file
+    repo.index.add(os.path.join(tmp_path, "test.py"))
 
     # Pass in custom arguments
     sys.argv[1:] = [
-        f"--loc={dirs[0]},{dirs[1]}",
+        "test.py",
         '--custom_copyright="Super cool copyright"',
         "--custom_template=test_template",
         "--custom_license=ECL-1.0",
@@ -187,37 +68,85 @@ def test_custom_args(tmp_path: pytest.TempPathFactory):
     # Assert main runs successfully with custom arguments
     assert res == 1
 
+    os.chdir(current_work_dir)
 
-def test_main_passes():
-    """Test all files are compliant."""
-    # Ensure you are always running from root path to repo
+
+def test_multiple_files(tmp_path: pytest.TempPathFactory):
+    """Test reuse is run on files without headers, when one file already has header."""
+    # Save current working directory
     current_work_dir = os.getcwd()
-    os.chdir(ROOT_DIR)
 
-    try:
-        sys.argv[1:] = ["--loc=src"]
+    template_name = "ansys.jinja2"
+    template_path = os.path.join(current_work_dir, ".reuse", "templates", template_name)
 
-        res = hook.main()
-        assert res == 0
-    finally:
-        os.chdir(current_work_dir)
+    # Change dir to tmp_path
+    os.chdir(tmp_path)
+
+    # Set up git repository in tmp_path
+    repo = init_git_repo(tmp_path, template_path, template_name)
+
+    # Create a test file in tmp_path
+    create_test_file(tmp_path, "test.py")
+
+    # Stage test.py file
+    repo.index.add(os.path.join(tmp_path, "test.py"))
+
+    # Pass in file arguments
+    sys.argv[1:] = ["test.py"]
+
+    hook.main()
+
+    # Add test.py with license header
+    repo.index.add(os.path.join(tmp_path, "test.py"))
+
+    # Create two new files to run REUSE on
+    new_files = ["test2.py", "test3.py"]
+    for file in new_files:
+        create_test_file(tmp_path, file)
+        repo.index.add(os.path.join(tmp_path, file))
+
+    # Pass in the file arguments
+    sys.argv[1:] = ["test.py", "test2.py", "test3.py"]
+
+    res = hook.main()
+
+    # Assert main runs successfully with custom arguments
+    assert res == 1
+
+    os.chdir(current_work_dir)
 
 
 def test_main_fails(tmp_path: pytest.TempPathFactory):
     """Test reuse is being run on noncompliant file."""
-    # Ensure you are always running from root path to repo
+    # Save current working directory
     current_work_dir = os.getcwd()
-    os.chdir(ROOT_DIR)
 
-    try:
-        sys.argv[1:] = [rf"--loc={tmp_path}"]
-        test_file = create_test_file(tmp_path)
+    template_name = "ansys.jinja2"
+    template_path = os.path.join(current_work_dir, ".reuse", "templates", template_name)
 
-        # Run main given non_compliant file
-        res = hook.main()
-        assert res == 1
+    # Change dir to tmp_path
+    os.chdir(tmp_path)
 
-    finally:
-        # Remove test file from git repo
-        os.remove(test_file)
-        os.chdir(current_work_dir)
+    # Set up git repository in tmp_path
+    repo = init_git_repo(tmp_path, template_path, template_name)
+
+    # Create a test file in tmp_path
+    create_test_file(tmp_path, "test.py")
+
+    # Stage test.py file
+    repo.index.add(os.path.join(tmp_path, "test.py"))
+
+    res = hook.main()
+
+    # Assert main runs successfully with custom arguments
+    assert res == 1
+
+    os.chdir(current_work_dir)
+
+
+def test_main_passes():
+    """Test all files are compliant."""
+    res = hook.main()
+
+    # Assert main runs successfully
+    assert res == 0

--- a/tests/test_template.jinja2
+++ b/tests/test_template.jinja2
@@ -6,7 +6,7 @@ This Educational Community License (the "License") applies to any original work 
 {{ copyright_line }}
 {% endfor %}
 {% for expression in spdx_expressions %}
-SPDX-License-Identifier: {{ expression }}
+{{ "SPDX" }}-License-Identifier: {{ expression }}
 {% endfor %}
 
 Licensed under the Educational Community License version 1.0


### PR DESCRIPTION
- Removed loc argument from the hook
- Allowed committed files to be passed into the hook

- Updated README
  - Removed loc argument info
  - Added how to exclude specific files, as well as specific file types either in the .reuse/dep5 or .pre-commit-config.yaml

Closes #46 and #56