### PR TITLE
Minor updates to .pre-commit-hooks.yaml and README

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -2,5 +2,4 @@
   name: "Add License Headers"
   entry: add-license-headers
   language: python
-  pass_filenames: false
   description: "Add missing license headers to files by using reuse lint and annotate"

--- a/README.rst
+++ b/README.rst
@@ -90,10 +90,10 @@ Currently, these hooks are available:
 
         There are two different ways to ignore specific files or file types:
 
-        #. In .pre-commit-config.yaml
-
+     #. In .pre-commit-config.yaml
+   
           .. code:: yaml
-
+   
            - repo: https://github.com/ansys/pre-commit-hooks
              rev: v0.1.3
              hooks:
@@ -104,25 +104,25 @@ Currently, these hooks are available:
                        path/to/.*\.md |
                        path/to/.*\.(ts|cpp) |
                    )$
-
+   
           .. note ::
-
+   
            - ``path/to/file1.py`` excludes the stated file.
            - ``path/to/.*\.md`` exlcudes all .md files within the ``path/to`` directory.
            - ``path/to/.*\.(ts|cpp)`` excludes all .ts and .cpp files within the ``path/to`` directory.
 
-        #. In .reuse/dep5
-
+     #. In .reuse/dep5
+   
           .. code:: debcontrol
-
+   
            Files: path/to/file1.py
            Copyright: 2023 ANSYS, Inc. and/or its affiliates.
            License: MIT
-
+   
            Files: path/to/*.py
            Copyright: 2023 ANSYS, Inc. and/or its affiliates.
            License: MIT
-
+   
           .. note::
            - ``path/to/file1.py`` excludes the stated file.
            - ``path/to/*.py`` excludes all .py files in the ``path/to`` directory.

--- a/README.rst
+++ b/README.rst
@@ -91,9 +91,9 @@ Currently, these hooks are available:
         There are two different ways to ignore specific files or file types:
 
      #. In .pre-commit-config.yaml
-   
+
           .. code:: yaml
-   
+
            - repo: https://github.com/ansys/pre-commit-hooks
              rev: v0.1.3
              hooks:
@@ -104,25 +104,25 @@ Currently, these hooks are available:
                        path/to/.*\.md |
                        path/to/.*\.(ts|cpp) |
                    )$
-   
+
           .. note ::
-   
+
            - ``path/to/file1.py`` excludes the stated file.
            - ``path/to/.*\.md`` exlcudes all .md files within the ``path/to`` directory.
            - ``path/to/.*\.(ts|cpp)`` excludes all .ts and .cpp files within the ``path/to`` directory.
 
      #. In .reuse/dep5
-   
+
           .. code:: debcontrol
-   
+
            Files: path/to/file1.py
            Copyright: 2023 ANSYS, Inc. and/or its affiliates.
            License: MIT
-   
+
            Files: path/to/*.py
            Copyright: 2023 ANSYS, Inc. and/or its affiliates.
            License: MIT
-   
+
           .. note::
            - ``path/to/file1.py`` excludes the stated file.
            - ``path/to/*.py`` excludes all .py files in the ``path/to`` directory.


### PR DESCRIPTION
- Remove "pass_filenames: false" from the hook yaml file 
- Fixed README numbering error