### PR TITLE
Added check_license argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This document follows the conventions laid out in [Keep a CHANGELOG](https://kee
 
 ### Added
 
+- Added check_license argument (#64)
+
 ### Changed
 
 - Removed loc argument & passed in committed files (#57)

--- a/README.rst
+++ b/README.rst
@@ -63,7 +63,7 @@ Currently, these hooks are available:
         rev: v0.1.3
         hooks:
         - id: add-license-headers
-          args: ["--custom_copyright", "custom copyright phrase", "--custom_template", "template_name", "--custom_license", "license_name"]
+          args: ["--custom_copyright", "custom copyright phrase", "--custom_template", "template_name", "--custom_license", "license_name", "--check_license", "False"]
 
      ``args`` can also be formatted as follows:
 
@@ -73,6 +73,7 @@ Currently, these hooks are available:
       - --custom_copyright=custom copyright phrase
       - --custom_template=template_name
       - --custom_license=license_name
+      - --check_license=False
 
      .. note::
 
@@ -83,6 +84,8 @@ Currently, these hooks are available:
       #. ``license_name`` is the name of the license being used. For example, MIT, ECL-1.0, etc.
          To view a list of licenses that are supported by ``REUSE``, see
          https://github.com/spdx/license-list-data/tree/main/text. By default it uses ``MIT``.
+      #. ``check_license`` is whether or not to check for the license in the file headers.
+         By default, it is set to ``True``.
 
   #. Ignore specific files or file types
 

--- a/README.rst
+++ b/README.rst
@@ -63,7 +63,7 @@ Currently, these hooks are available:
         rev: v0.1.3
         hooks:
         - id: add-license-headers
-          args: ["--custom_copyright", "custom copyright phrase", "--custom_template", "template_name", "--custom_license", "license_name", "--check_license", "False"]
+          args: ["--custom_copyright", "custom copyright phrase", "--custom_template", "template_name", "--custom_license", "license_name", "--ignore_license_check"]
 
      ``args`` can also be formatted as follows:
 
@@ -73,7 +73,7 @@ Currently, these hooks are available:
       - --custom_copyright=custom copyright phrase
       - --custom_template=template_name
       - --custom_license=license_name
-      - --check_license=False
+      - --ignore_license_check
 
      .. note::
 
@@ -84,8 +84,10 @@ Currently, these hooks are available:
       #. ``license_name`` is the name of the license being used. For example, MIT, ECL-1.0, etc.
          To view a list of licenses that are supported by ``REUSE``, see
          https://github.com/spdx/license-list-data/tree/main/text. By default it uses ``MIT``.
-      #. ``check_license`` is whether or not to check for the license in the file headers.
-         By default, it is set to ``True``.
+      #. ``ignore_license_check`` is whether or not to check for the license in the header. By default,
+         it is ``False``, meaning the files are checked for both the copyright and licensing information
+         in the header. Add ``--ignore_license_check`` to ignore checking for licensing information
+         in the files.
 
   #. Ignore specific files or file types
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ doc = [
     "ansys-sphinx-theme==0.11.2",
     "numpydoc==1.5.0",
     "sphinx==7.2.6",
-    "sphinx-autoapi==2.1.1",
+    "sphinx-autoapi==3.0.0",
     "sphinx-autodoc-typehints==1.24.0",
     "sphinx-copybutton==0.5.1",
 ]

--- a/src/ansys/pre_commit_hooks/add_license_headers.py
+++ b/src/ansys/pre_commit_hooks/add_license_headers.py
@@ -80,12 +80,8 @@ def set_lint_args(parser):
         help="Default license for headers.",
         default=DEFAULT_LICENSE,
     )
-    parser.add_argument(
-        "--check_license",
-        type=str,
-        help="Whether or not to check for the license in the header.",
-        default="True",
-    )
+    # Ignore license check by default is False when action='store_true'
+    parser.add_argument("--ignore_license_check", action="store_true")
     parser.add_argument("--parser")
     parser.add_argument("--no_multiprocessing", action="store_true")
     lint.add_arguments(parser)
@@ -125,8 +121,8 @@ def list_noncompliant_files(args, proj):
     # Get files missing copyright information
     missing_headers = set(lint_json["non_compliant"]["missing_copyright_info"])
 
-    # Get files missing licensing information if True
-    if args.check_license == "True":
+    # If ignore_license_check is False, check files for missing licensing information
+    if not args.ignore_license_check:
         missing_licensing_info = set(lint_json["non_compliant"]["missing_licensing_info"])
         missing_headers = missing_headers.union(missing_licensing_info)
 

--- a/src/ansys/pre_commit_hooks/add_license_headers.py
+++ b/src/ansys/pre_commit_hooks/add_license_headers.py
@@ -80,6 +80,12 @@ def set_lint_args(parser):
         help="Default license for headers.",
         default=DEFAULT_LICENSE,
     )
+    parser.add_argument(
+        "--check_license",
+        type=str,
+        help="Whether or not to check for the license in the header.",
+        default="True",
+    )
     parser.add_argument("--parser")
     parser.add_argument("--no_multiprocessing", action="store_true")
     lint.add_arguments(parser)
@@ -116,10 +122,13 @@ def list_noncompliant_files(args, proj):
     with open(filename, "rb") as file:
         lint_json = json.load(file)
 
-    missing_headers = set(
-        lint_json["non_compliant"]["missing_copyright_info"]
-        + lint_json["non_compliant"]["missing_licensing_info"]
-    )
+    # Get files missing copyright information
+    missing_headers = set(lint_json["non_compliant"]["missing_copyright_info"])
+
+    # Get files missing licensing information if True
+    if args.check_license == "True":
+        missing_licensing_info = set(lint_json["non_compliant"]["missing_licensing_info"])
+        missing_headers = missing_headers.union(missing_licensing_info)
 
     # Remove temporary file
     os.remove(filename)

--- a/tests/test_reuse.py
+++ b/tests/test_reuse.py
@@ -1,3 +1,4 @@
+import argparse
 import os
 import shutil
 import sys
@@ -150,3 +151,20 @@ def test_main_passes():
 
     # Assert main runs successfully
     assert res == 0
+
+
+def test_license_check():
+    """Test license is checked in the header."""
+    parser = argparse.ArgumentParser()
+    args = hook.set_lint_args(parser)
+
+    assert args.ignore_license_check == False
+
+
+def test_no_license_check():
+    """Test license check is ignored."""
+    sys.argv[1:] = ["--ignore_license_check"]
+    parser = argparse.ArgumentParser()
+    args = hook.set_lint_args(parser)
+
+    assert args.ignore_license_check == True


### PR DESCRIPTION
Added check_license argument for cases when the header does not contain a license, so you don't want to check if it exists in the header. Closes #62