### PR TITLE
Create assets folder with common REUSE templates

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -37,25 +37,56 @@ Currently, these hooks are available:
   `REUSE <https://reuse.software/>`_ . To use this hook, you must
   have ``REUSE`` implemented in your repository.
 
-  #. Copy the .reuse directory from this repository into your repository.
+ #. If you are using any custom templates or licenses, copy the .reuse and LICENSES directories from this repository
+    into the target repository. If you are using the default ansys template and MIT.txt license, skip this step. By default,
+    the hook will copy the LICENSES/MIT.txt, .reuse/templates/ansys.jinja2, and .reuse/dep5 into the target repository when
+    the hook runs.
 
      .. note::
 
-        Configure .reuse/dep5 to match the file structure within your repository.
+        The LICENSES and .reuse folders are required for the hook to run correctly. Your project
+        should have the following layout:
+
+        ::
+
+            project
+            ├── LICENCES
+            │   └── license_name.txt
+            ├── .reuse
+            │   └── templates
+            │       └── template_name.jinja2
+            │   └── dep5
+            ├── src
+            ├── examples
+            ├── tests
+            ├── .pre-commit-config.yaml
+            ├── pyproject.toml
+
+        Where ``license_name`` is the name of the license that is being used, for example, MIT.txt, and
+        ``template_name`` is the name of the custom template being used. The jinja2 file contains the
+        template for the license headers that are added to the files.
+
+        Licenses that are supported by ``REUSE`` can be found in the
+        `spdx/license-list-data <https://github.com/spdx/license-list-data/tree/main/text>`_ repository.
+        Please select a license text file from that repository, and copy it to the LICENSES directory.
+
+ #. Configure the .reuse/dep5 file.
+
+     .. note::
+
+        If the default template and license are being used, run the hook to acquire the
+        .reuse and LICENSES directories. After running the hook, if files in your project
+        contain headers that should not, configure the .reuse/dep5 file to match the file
+        structure within your repository and run the hook again.
+
+        If you are manually setting up the .reuse and LICENSES directories,
+        ensure the .reuse/dep5 entries match the file structure within your repository.
         The dep5 file contains files & directories that should not be given license headers.
         Ensure all files and directories you want to ignore are in this file.
 
-        .reuse/templates/ansys.jinja2 contains the template for the license headers that are
-        added to the files. If the content of the MIT license changes, replace the lines between
-        the if statements in the following code block:
+        See step #5 for examples of how to ignore specific files in dep5.
 
-        .. code:: jinja
-
-           {% if "MIT" in spdx_expressions %}
-           ...
-           {% endif %}
-
-  #. Set custom arguments for the pre-commit hook if necessary.
+ #. Set custom arguments for the pre-commit hook if necessary.
 
      .. code:: yaml
 
@@ -89,7 +120,7 @@ Currently, these hooks are available:
          in the header. Add ``--ignore_license_check`` to ignore checking for licensing information
          in the files.
 
-  #. Specify directories to run the hook on
+ #. Specify directories to run the hook on
 
      .. note::
 
@@ -106,7 +137,7 @@ Currently, these hooks are available:
         - id: add-license-headers
           files: '(src|examples|tests|newFolder)/.*\.(py|newExtension)|\.(proto|newExtension)'
 
-  #. Ignore specific files or file types
+ #. Ignore specific files or file types
 
      .. note::
 

--- a/src/ansys/pre_commit_hooks/add_license_headers.py
+++ b/src/ansys/pre_commit_hooks/add_license_headers.py
@@ -29,6 +29,8 @@ import argparse
 from datetime import date as dt
 import json
 import os
+import pathlib
+import shutil
 import sys
 from tempfile import NamedTemporaryFile
 
@@ -87,6 +89,41 @@ def set_lint_args(parser):
     lint.add_arguments(parser)
 
     return parser.parse_args()
+
+
+def copy_assets(proj_root, args):
+    """Copy .reuse and LICENSES folders from assets directory."""
+    hook_loc = pathlib.Path(__file__).parent.resolve()
+    directories = [".reuse"]
+
+    # If ignore_license_check is False, copy LICENSES folder to
+    # the root of the repository
+    if not args.ignore_license_check:
+        directories.append("LICENSES")
+
+    for dir in directories:
+        src = os.path.join(hook_loc, "assets", dir)
+        dest = os.path.join(proj_root, dir)
+
+        # If .reuse or LICENSES exists in the root of the repository,
+        # only replace .reuse/templates/ansys.jinja2 and LICENSES/MIT.txt
+        if os.path.isdir(dest):
+            if ".reuse" in dest:
+                src_file = os.path.join(src, "templates", "ansys.jinja2")
+                dest_file = os.path.join(dest, "templates", "ansys.jinja2")
+            elif "LICENSES" in dest:
+                src_file = os.path.join(src, "MIT.txt")
+                dest_file = os.path.join(dest, "MIT.txt")
+
+            if os.path.isfile(dest_file):
+                # Remove destination file & replace with
+                # a new copy from source
+                os.remove(dest_file)
+                shutil.copyfile(src_file, dest_file)
+        else:
+            # If destination directory does not exist, copy the entire
+            # folder from src to dest
+            shutil.copytree(src, dest)
 
 
 def list_noncompliant_files(args, proj):
@@ -249,6 +286,7 @@ def get_full_paths(file_list):
         List containing the full paths of committed files.
     """
     full_path_files = []
+    print(file_list)
     for file in file_list:
         if "win" in sys.platform:
             split_str = file.split("/")
@@ -293,8 +331,6 @@ def find_files_missing_header():
         "git_repo": git_repo,
     }
 
-    # Update file paths to be absolute paths with correct separators
-
     # Add header arguments to parser. Arguments are: copyright, license, contributor,
     # year, style, copyright-style, template, exclude-year, merge-copyrights, single-line,
     # multi-line, explicit-license, force-dot-license, recursive, no-replace,
@@ -303,6 +339,10 @@ def find_files_missing_header():
 
     # Run REUSE on root of the repository
     git_root = values["git_repo"].git.rev_parse("--show-toplevel")
+
+    # Copy .reuse folder and LICENSES folder (if licenses are being checked)
+    copy_assets(git_root, args)
+
     proj = project.Project(git_root)
 
     # Get files missing headers (copyright and/or license information)

--- a/src/ansys/pre_commit_hooks/assets/.reuse/dep5
+++ b/src/ansys/pre_commit_hooks/assets/.reuse/dep5
@@ -1,0 +1,80 @@
+Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
+Upstream-Name: pre-commit-hooks
+Upstream-Contact: pyansys.core@ansys.com
+Source: https://github.com/ansys/pre-commit-hooks
+
+Files: .github/*
+Copyright: 2023 ANSYS, Inc. and/or its affiliates.
+License: MIT
+
+Files: .reuse/*
+Copyright: 2023 ANSYS, Inc. and/or its affiliates.
+License: MIT
+
+Files: doc/*
+Copyright: 2023 ANSYS, Inc. and/or its affiliates.
+License: MIT
+
+Files: examples/*
+Copyright: 2023 ANSYS, Inc. and/or its affiliates.
+License: MIT
+
+Files: LICENSES/*
+Copyright: 2023 ANSYS, Inc. and/or its affiliates.
+License: MIT
+
+Files: tests/*
+Copyright: 2023 ANSYS, Inc. and/or its affiliates.
+License: MIT
+
+Files: .flake8
+Copyright: 2023 ANSYS, Inc. and/or its affiliates.
+License: MIT
+
+Files: .gitattributes
+Copyright: 2023 ANSYS, Inc. and/or its affiliates.
+License: MIT
+
+Files: .gitignore
+Copyright: 2023 ANSYS, Inc. and/or its affiliates.
+License: MIT
+
+Files: .pre-commit-config.yaml
+Copyright: 2023 ANSYS, Inc. and/or its affiliates.
+License: MIT
+
+Files: .pre-commit-hooks.yaml
+Copyright: 2023 ANSYS, Inc. and/or its affiliates.
+License: MIT
+
+Files: AUTHORS
+Copyright: 2023 ANSYS, Inc. and/or its affiliates.
+License: MIT
+
+Files: CHANGELOG.md
+Copyright: 2023 ANSYS, Inc. and/or its affiliates.
+License: MIT
+
+Files: CODE_OF_CONDUCT.md
+Copyright: 2023 ANSYS, Inc. and/or its affiliates.
+License: MIT
+
+Files: CONTRIBUTING.md
+Copyright: 2023 ANSYS, Inc. and/or its affiliates.
+License: MIT
+
+Files: CONTRIBUTORS.md
+Copyright: 2023 ANSYS, Inc. and/or its affiliates.
+License: MIT
+
+Files: pyproject.toml
+Copyright: 2023 ANSYS, Inc. and/or its affiliates.
+License: MIT
+
+Files: README.rst
+Copyright: 2023 ANSYS, Inc. and/or its affiliates.
+License: MIT
+
+Files: tox.ini
+Copyright: 2023 ANSYS, Inc. and/or its affiliates.
+License: MIT

--- a/src/ansys/pre_commit_hooks/assets/.reuse/templates/ansys.jinja2
+++ b/src/ansys/pre_commit_hooks/assets/.reuse/templates/ansys.jinja2
@@ -1,0 +1,27 @@
+{% for copyright_line in copyright_lines %}
+{{ copyright_line }}
+{% endfor %}
+{% for expression in spdx_expressions %}
+SPDX-License-Identifier: {{ expression }}
+{% endfor %}
+
+
+{% if "MIT" in spdx_expressions %}
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+{% endif %}

--- a/src/ansys/pre_commit_hooks/assets/LICENSES/MIT.txt
+++ b/src/ansys/pre_commit_hooks/assets/LICENSES/MIT.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023 ANSYS, Inc. and/or its affiliates.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
- Created assets folder with common REUSE templates 
  - .reuse/templates/ansys.jinja2
  - .reuse/dep5
  - LICENSES/MIT.txt

- Added code that copies the .reuse and LICENSES folders within assets to the root of the target repository. If the user has the default ansys.jinja2 and MIT.txt templates, they are updated each time the hook is run. The dep5 file is not updated since it is unique to the repository it resides in.

- Updated README

Closes #45