### PR TITLE
Run add-license-headers hook serially

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -4,3 +4,4 @@
   language: python
   description: "Add missing license headers to files by using reuse lint and annotate"
   files: '(src|examples|tests)/.*\.(py)|\.(proto)'
+  require_serial: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This document follows the conventions laid out in [Keep a CHANGELOG](https://kee
 - Run hook on specific directories and files ([#65](https://github.com/ansys/pre-commit-hooks/pull/65))
 - Update headers & improve unit tests ([#69](https://github.com/ansys/pre-commit-hooks/pull/69))
 - Create assets folder with common REUSE templates ([#72](https://github.com/ansys/pre-commit-hooks/pull/72))
+- Run add-license-headers hook serially ([#74](https://github.com/ansys/pre-commit-hooks/pull/74))
 
 ### Changed
 


### PR DESCRIPTION
By default, hooks run parallel when given --all-files. This was causing issues with copying over the .reuse/ansys.jinja2 and LICENSES/MIT.txt files. I had to change the hook to run serially so it would only try copying over those files once