### PR TITLE
fix: line length over 79 chars

### DIFF
--- a/src/ansys/pre_commit_hooks/assets/.reuse/templates/ansys.jinja2
+++ b/src/ansys/pre_commit_hooks/assets/.reuse/templates/ansys.jinja2
@@ -14,8 +14,8 @@ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 copies of the Software, and to permit persons to whom the Software is
 furnished to do so, subject to the following conditions:
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,

--- a/src/ansys/pre_commit_hooks/assets/LICENSES/MIT.txt
+++ b/src/ansys/pre_commit_hooks/assets/LICENSES/MIT.txt
@@ -9,8 +9,8 @@ use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
 of the Software, and to permit persons to whom the Software is furnished to do
 so, subject to the following conditions:
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,


### PR DESCRIPTION
Many libraries may not have configured their line length to be 88, 100 etc. and use the default 79 chars for ``flake8``. In those cases, the hook fails. Adapting line length to fulfil 79 chars reqs.