### PR TITLE
feat: update the year in the LICENSE based on the start_year argument

### DIFF
--- a/src/ansys/pre_commit_hooks/add_license_headers.py
+++ b/src/ansys/pre_commit_hooks/add_license_headers.py
@@ -161,7 +161,6 @@ def mkdirs_and_link(
         os.makedirs(asset_dir)
     # Make symbolic links to files within the assets folder
     os.symlink(src, dest)
-    print(dest)
 
 
 def list_noncompliant_files(args: argparse.Namespace, proj: project.Project) -> list:
@@ -192,8 +191,6 @@ def list_noncompliant_files(args: argparse.Namespace, proj: project.Project) -> 
     lint_json = None
     with open(filename, "rb") as file:
         lint_json = json.load(file)
-
-    # print(json.dumps(lint_json, indent=4, sort_keys=True))
 
     # Get files missing copyright information
     missing_headers = set(lint_json["non_compliant"]["missing_copyright_info"])
@@ -340,6 +337,7 @@ def check_exists(
             os.remove(before_hook)
 
             return check_exists(changed_headers, parser, values, proj, missing_headers, i + 1)
+
     return changed_headers
 
 

--- a/src/ansys/pre_commit_hooks/add_license_headers.py
+++ b/src/ansys/pre_commit_hooks/add_license_headers.py
@@ -598,9 +598,8 @@ def find_files_missing_header() -> int:
         "git_repo": git_repo,
     }
 
+    # Update the year in the copyright line of the LICENSE file
     license_return_code = update_license_file(values)
-    if license_return_code == 1:
-        print("Successfully updated year of LICENSE")
 
     # Run REUSE on root of the repository
     git_root = values["git_repo"].git.rev_parse("--show-toplevel")

--- a/tests/test_reuse.py
+++ b/tests/test_reuse.py
@@ -267,7 +267,6 @@ def test_multiple_files(tmp_path: pytest.TempPathFactory):
     assert add_argv_run(repo, new_files, new_files) == 1
 
     for file in new_files:
-        print(f"checking {file}")
         check_ansys_header(file)
 
     os.chdir(REPO_PATH)

--- a/tests/test_reuse_files/LICENSES/LICENSE
+++ b/tests/test_reuse_files/LICENSES/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 ANSYS, Inc. and/or its affiliates.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
- Copy assets/LICENSES/MIT.txt to LICENSE in the root of the repository if using the default license
- Update the year in the copyright line of the LICENSE file based on the start_year argument

Closes #117, #141 