### PR TITLE
fix: add recursive argument and code to add-license-headers

### DIFF
--- a/doc/changelog.d/182.dependencies.md
+++ b/doc/changelog.d/182.dependencies.md
@@ -1,0 +1,1 @@
+build(deps): bump sphinx-autodoc-typehints from 2.1.0 to 2.1.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ doc = [
     "ansys-sphinx-theme[autoapi]==0.16.5",
     "numpydoc==1.7.0",
     "sphinx==7.3.7",
-    "sphinx-autodoc-typehints==2.1.0",
+    "sphinx-autodoc-typehints==2.1.1",
     "sphinx-copybutton==0.5.1",
 ]
 

--- a/src/ansys/pre_commit_hooks/add_license_headers.py
+++ b/src/ansys/pre_commit_hooks/add_license_headers.py
@@ -95,7 +95,6 @@ def set_lint_args(parser: argparse.ArgumentParser) -> argparse.Namespace:
     )
     # Ignore license check by default is False when action='store_true'
     parser.add_argument("--ignore_license_check", action="store_true")
-    parser.add_argument("--non_recursive_file_check", action="store_true")
     parser.add_argument("--parser")
     parser.add_argument("--no_multiprocessing", action="store_true")
     lint.add_arguments(parser)
@@ -712,7 +711,7 @@ def find_files_missing_header() -> int:
 
     # Add or update headers of required files.
     # Return 1 if files were added or updated, and return 0 if no files were altered.
-    if args.non_recursive_file_check:
+    if len(values["files"]) > 995:
         file_return_code = non_recursive_file_check(
             changed_headers, parser, values, proj, missing_headers
         )

--- a/src/ansys/pre_commit_hooks/add_license_headers.py
+++ b/src/ansys/pre_commit_hooks/add_license_headers.py
@@ -711,13 +711,13 @@ def find_files_missing_header() -> int:
 
     # Add or update headers of required files.
     # Return 1 if files were added or updated, and return 0 if no files were altered.
-    if len(values["files"]) > 995:
-        file_return_code = non_recursive_file_check(
-            changed_headers, parser, values, proj, missing_headers
-        )
-    else:
+    if len(values["files"]) <= (sys.getrecursionlimit() - 2):
         file_return_code = recursive_file_check(
             changed_headers, parser, values, proj, missing_headers, 0
+        )
+    else:
+        file_return_code = non_recursive_file_check(
+            changed_headers, parser, values, proj, missing_headers
         )
 
     # Unlink default files & remove .reuse and LICENSES folders if empty

--- a/tests/test_reuse.py
+++ b/tests/test_reuse.py
@@ -641,7 +641,7 @@ def test_no_recursion(tmp_path: pytest.TempPathFactory):
     # Add file with updated header
     repo.index.add([tmp_file])
 
-    for file in range(0, 1000):
+    for file in range(0, sys.getrecursionlimit() + 1):
         # Create temporary python file
         new_file = create_test_file(tmp_path)
         # Git add new file

--- a/tests/test_reuse.py
+++ b/tests/test_reuse.py
@@ -633,7 +633,7 @@ def test_no_recursion(tmp_path: pytest.TempPathFactory):
     # Set up git repository in tmp_path with temporary file
     repo, tmp_file = set_up_repo(tmp_path, template_path, template_name, license_path, license_name)
     new_files.append(tmp_file)
-    custom_args = [tmp_file, f"--start_year={START_YEAR}", "--non_recursive_file_check"]
+    custom_args = [tmp_file, f"--start_year={START_YEAR}"]
 
     # Git add tmp_file and run hook with custom arguments
     assert add_argv_run(repo, tmp_file, custom_args) == 1
@@ -641,15 +641,15 @@ def test_no_recursion(tmp_path: pytest.TempPathFactory):
     # Add file with updated header
     repo.index.add([tmp_file])
 
-    # Create temporary python file
-    new_file = create_test_file(tmp_path)
-    # Git add new file
-    repo.index.add(new_file)
-    # Append file to new_files list
-    new_files.append(new_file)
-
-    # Add new file without header to custom_args
-    custom_args.insert(0, new_file)
+    for file in range(0, 1000):
+        # Create temporary python file
+        new_file = create_test_file(tmp_path)
+        # Git add new file
+        repo.index.add(new_file)
+        # Append file to new_files list
+        new_files.append(new_file)
+        # Add new file without header to custom_args
+        custom_args.insert(0, new_file)
 
     assert add_argv_run(repo, new_files, custom_args) == 1
 


### PR DESCRIPTION
Add recursive argument and code to the add-license-headers hook. By default, the recursive method will be used to check the headers in the files. For large repositories that break with recursion, add the "--non_recursive_file_check" argument to the hook in the .pre-commit-config.yaml file