### PR TITLE
chore: update CHANGELOG for v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,31 @@ This project uses [towncrier](https://towncrier.readthedocs.io/) and the changes
 
 <!-- towncrier release notes start -->
 
+## [0.4.0](https://github.com/ansys/pre-commit-hooks/releases/tag/v0.4.0) - 2024-07-01
+
+
+### Added
+
+- feat: technical review hook [#183](https://github.com/ansys/pre-commit-hooks/pull/183)
+
+
+### Changed
+
+- chore: update CHANGELOG for v0.3.2 [#186](https://github.com/ansys/pre-commit-hooks/pull/186)
+
+
+### Dependencies
+
+- build(deps): bump importlib-metadata from 7.1.0 to 7.2.1 [#187](https://github.com/ansys/pre-commit-hooks/pull/187)
+- build(deps): bump sphinx-autodoc-typehints from 2.1.1 to 2.2.2 [#188](https://github.com/ansys/pre-commit-hooks/pull/188)
+- build(deps): bump ansys-sphinx-theme[autoapi] from 0.16.5 to 0.16.6 [#189](https://github.com/ansys/pre-commit-hooks/pull/189)
+- build(deps): bump importlib-metadata from 7.2.1 to 8.0.0 [#192](https://github.com/ansys/pre-commit-hooks/pull/192)
+
+
+### Miscellaneous
+
+- [pre-commit.ci] pre-commit autoupdate [#190](https://github.com/ansys/pre-commit-hooks/pull/190)
+
 ## [0.3.2](https://github.com/ansys/pre-commit-hooks/releases/tag/v0.3.2) - 2024-06-20
 
 

--- a/doc/changelog.d/183.added.md
+++ b/doc/changelog.d/183.added.md
@@ -1,1 +1,0 @@
-feat: technical review hook

--- a/doc/changelog.d/186.changed.md
+++ b/doc/changelog.d/186.changed.md
@@ -1,1 +1,0 @@
-chore: update CHANGELOG for v0.3.2

--- a/doc/changelog.d/187.dependencies.md
+++ b/doc/changelog.d/187.dependencies.md
@@ -1,1 +1,0 @@
-build(deps): bump importlib-metadata from 7.1.0 to 7.2.1

--- a/doc/changelog.d/188.dependencies.md
+++ b/doc/changelog.d/188.dependencies.md
@@ -1,1 +1,0 @@
-build(deps): bump sphinx-autodoc-typehints from 2.1.1 to 2.2.2

--- a/doc/changelog.d/189.dependencies.md
+++ b/doc/changelog.d/189.dependencies.md
@@ -1,1 +1,0 @@
-build(deps): bump ansys-sphinx-theme[autoapi] from 0.16.5 to 0.16.6

--- a/doc/changelog.d/190.miscellaneous.md
+++ b/doc/changelog.d/190.miscellaneous.md
@@ -1,1 +1,0 @@
-[pre-commit.ci] pre-commit autoupdate

--- a/doc/changelog.d/192.dependencies.md
+++ b/doc/changelog.d/192.dependencies.md
@@ -1,1 +1,0 @@
-build(deps): bump importlib-metadata from 7.2.1 to 8.0.0

--- a/doc/changelog.d/193.changed.md
+++ b/doc/changelog.d/193.changed.md
@@ -1,0 +1,1 @@
+chore: update CHANGELOG for v0.4.0


### PR DESCRIPTION
Update CHANGELOG for v0.4.0 and remove .md files in doc/changelog.d