### PR TITLE
Fix semantic versioning check in tech-review hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -44,7 +44,7 @@ repos:
     - id: check-github-workflows
 
 - repo: https://github.com/ansys/pre-commit-hooks
-  rev: v0.3.1
+  rev: v0.4.0
   hooks:
   - id: add-license-headers
     args:
@@ -54,3 +54,7 @@ repos:
             tests/test_reuse_files/bad_chars.py |
             tests/test_reuse_files/index_error.scss
         )$
+  # - id: tech-review
+  #   args:
+  #   - --product=pre_commit_hooks
+  #   - --non_compliant_name

--- a/src/ansys/pre_commit_hooks/tech_review.py
+++ b/src/ansys/pre_commit_hooks/tech_review.py
@@ -229,8 +229,9 @@ def check_pyproject_toml(
             try:
                 version = semver.Version.parse(project_version)
             except ValueError:
-                is_compliant = False
-                print("Project version does not follow semantic versioning")
+                if not bool(re.match(r"^[0-9]+.[0-9]+.dev[0-9]+$", project_version)):
+                    is_compliant = False
+                    print("Project version does not follow semantic versioning")
 
         # Check the project author and maintainer names and emails match argument input
         category, metadata = ["authors", "maintainers"], ["name", "email"]

--- a/tests/test_tech_review.py
+++ b/tests/test_tech_review.py
@@ -228,6 +228,26 @@ def test_bad_version(tmp_path: pytest.TempPathFactory, capsys):
 
 
 @pytest.mark.tech_review
+def test_dev_version(tmp_path: pytest.TempPathFactory, capsys):
+    """Test the error message appears when the project does not use semantic versioning."""
+    tmp_path = tmp_path / "pytechreview"
+    setup_repo(tmp_path)
+
+    # Replace the version in the pyproject.toml file to be invalid
+    search = 'version = "0.1.0"'
+    replace = 'version = "11.1.dev1"'
+    replace_line(tmp_path, "pyproject.toml", search, replace)
+
+    assert hook.main() == 1
+
+    # Check error message is printed
+    output = capsys.readouterr()
+    assert "Project version does not follow semantic versioning" not in output.out
+
+    os.chdir(REPO_PATH)
+
+
+@pytest.mark.tech_review
 def test_bad_author_maint_name_email(tmp_path: pytest.TempPathFactory, capsys):
     """Test the error message appears when author and maintainers name and emails do not exist."""
     tmp_path = tmp_path / "pytechreview"


### PR DESCRIPTION
Fix semver check for strings that contain "dev," like "11.0.dev1"

The semver PyPI package marks this version format as invalid