### PR TITLE
chore: adjust add-license-headers script to work with reuse 4.0.3

### DIFF
--- a/doc/changelog.d/211.changed.md
+++ b/doc/changelog.d/211.changed.md
@@ -1,0 +1,1 @@
+chore: adjust add-license-headers script to work with reuse 4.0.3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = [
     "setuptools>=42.0",
     "GitPython==3.1.43",
     "Jinja2==3.1.4",
-    "reuse==3.0.2",
+    "reuse==4.0.3",
     "requests==2.32.3",
     "semver==3.0.2",
     "toml==0.10.2",

--- a/setup.py
+++ b/setup.py
@@ -71,7 +71,7 @@ setup(
         "GitPython==3.1.43",
         "importlib-metadata==8.2.0",
         "Jinja2==3.1.4",
-        "reuse==3.0.2",
+        "reuse==4.0.3",
         "requests==2.32.3",
         "semver==3.0.2",
         "toml==0.10.2",

--- a/src/ansys/pre_commit_hooks/add_license_headers.py
+++ b/src/ansys/pre_commit_hooks/add_license_headers.py
@@ -97,7 +97,10 @@ def set_lint_args(parser: argparse.ArgumentParser) -> argparse.Namespace:
     parser.add_argument("--ignore_license_check", action="store_true")
     parser.add_argument("--parser")
     parser.add_argument("--no_multiprocessing", action="store_true")
-    lint.add_arguments(parser)
+
+    # Option for printing lint output
+    mutex_group = parser.add_mutually_exclusive_group()
+    mutex_group.add_argument("-q", "--quiet", action="store_true")
 
     return parser.parse_args()
 
@@ -241,7 +244,7 @@ def set_header_args(
         args.year = [current_year]
     else:
         args.year = [int(start_year), current_year]
-    args.copyright_style = "string-c"
+    args.copyright_prefix = "string-c"
     args.copyright = [copyright]
     args.merge_copyrights = True
     args.template = template
@@ -697,7 +700,7 @@ def find_files_missing_header() -> int:
     # year, style, copyright-style, template, exclude-year, merge-copyrights, single-line,
     # multi-line, explicit-license, force-dot-license, recursive, no-replace,
     # skip-unrecognized, and skip-existing
-    # header.add_arguments(parser)
+    print(args)
     _annotate.add_arguments(parser)
 
     # Link the default template and/or license from the assets folder to your git repo.

--- a/src/ansys/pre_commit_hooks/add_license_headers.py
+++ b/src/ansys/pre_commit_hooks/add_license_headers.py
@@ -700,7 +700,6 @@ def find_files_missing_header() -> int:
     # year, style, copyright-style, template, exclude-year, merge-copyrights, single-line,
     # multi-line, explicit-license, force-dot-license, recursive, no-replace,
     # skip-unrecognized, and skip-existing
-    print(args)
     _annotate.add_arguments(parser)
 
     # Link the default template and/or license from the assets folder to your git repo.

--- a/tests/test_reuse.py
+++ b/tests/test_reuse.py
@@ -184,8 +184,7 @@ def test_start_year_same_as_current(tmp_path: pytest.TempPathFactory):
     count = 0
     for line in file:
         count += 1
-        # Assert the copyright line's time range is
-        # from 2023 to the current year
+        # Assert the copyright line's time range is from 2023 to the current year
         if count == 1:
             assert f"Copyright (C) {dt.today().year} ANSYS, Inc." in line
         if count > 1:


### PR DESCRIPTION
Remove interfering arguments, change the copyright_style argument to copyright_prefix, and bump the reuse dependency to 4.0.3

Closes #197 