### PR TITLE
perf: avoiding file writing and skipping project directories

### DIFF
--- a/doc/changelog.d/215.added.md
+++ b/doc/changelog.d/215.added.md
@@ -1,0 +1,1 @@
+perf: avoiding file writing and skipping project directories

--- a/src/ansys/pre_commit_hooks/add_license_headers.py
+++ b/src/ansys/pre_commit_hooks/add_license_headers.py
@@ -33,15 +33,13 @@ import json
 import os
 import pathlib
 from platform import python_version
+import re
 import shutil
 import sys
 from tempfile import NamedTemporaryFile
-import re
 
 import git
-from reuse import _annotate, _util, lint, project
-
-from reuse import _IGNORE_DIR_PATTERNS
+from reuse import _IGNORE_DIR_PATTERNS, _annotate, _util, lint, project
 
 OWN_IGNORES = [
     re.compile(r"^\.venv$"),


### PR DESCRIPTION
As the title, improving hook by avoiding writing to file and skipping directories when building REUSE project.

Discussion/reasoning/logic/etc in #214 


Close #214 