### PR TITLE
feat: leverage reuse vcs Git strategy

### DIFF
--- a/src/ansys/pre_commit_hooks/add_license_headers.py
+++ b/src/ansys/pre_commit_hooks/add_license_headers.py
@@ -39,6 +39,7 @@ from tempfile import NamedTemporaryFile
 
 import git
 from reuse import _annotate, _util, lint, project
+from reuse.vcs import VCSStrategyGit
 
 DEFAULT_TEMPLATE = "ansys"
 """Default template to use for license headers."""
@@ -706,7 +707,7 @@ def find_files_missing_header() -> int:
     link_assets(assets, os_git_root, args)
 
     # Project to run `REUSE <https://reuse.software/>`_ on
-    proj = project.Project(git_root)
+    proj = project.Project(git_root, vcs_strategy=VCSStrategyGit)
 
     # Get files missing headers (copyright and/or license information)
     missing_headers = list(list_noncompliant_files(args, proj))


### PR DESCRIPTION
Seems like a big overhead when using `add-license-header` is related to the fact that we also handle (uselessly) files and directory ignored by version control. This PR adds `VCSStrategyGit` which should handle Git related ignores when checking a repo.

I did a test with this branch on pyaedt and the restitution time difference is huge.

Using
```
- repo: https://github.com/SMoraisAnsys/pre-commit-hooks
  rev: feat/use-reuse-ignore-vcs
```
took seconds when a file was modified while the using the current pre-commit-hooks takes minute(s)
```
- repo: https://github.com/ansys/pre-commit-hooks
  rev: v0.4.2
```

If this PR gets merged we should close #215
Closes #214