### PR TITLE
fix: LICENSE line endings

### DIFF
--- a/src/ansys/pre_commit_hooks/add_license_headers.py
+++ b/src/ansys/pre_commit_hooks/add_license_headers.py
@@ -514,7 +514,30 @@ def get_full_paths(file_list: list) -> list:
     return full_path_files
 
 
-def update_license_file(arg_dict):
+def replace_windows_line_endings(license_file: str) -> None:
+    """
+    Replace Windows line endings with Unix line endings if applicable.
+
+    Parameters
+    ----------
+    license_file: str
+        The license file to check.
+    """
+    windows_line_ending = b"\r\n"
+    # Get text of license_file
+    with open(license_file, "rb") as file:
+        text = file.read()
+
+    if windows_line_ending in text:
+        # Replace Windows line endings with Unix line endings
+        text = text.replace(windows_line_ending, b"\n")
+
+        # Overwrite the license file with Unix line endings
+        with open(license_file, "wb") as file:
+            file.write(text)
+
+
+def update_license_file(arg_dict: dict) -> int:
     """
     Update the LICENSE file to match MIT.txt, adjusting the year span to each repository.
 
@@ -583,18 +606,20 @@ def update_license_file(arg_dict):
                     else:
                         # Replace the existing copyright years with the new year_range
                         line = line.replace(line[paren_index:cpright_index], year_range)
-                    print(line.rstrip().replace("\r\n", "\n"))
+                    print(line.rstrip())
                 else:
                     if "-" in line:
                         # If there is a year range in the existing LICENSE file, but the
                         # start_year and current_year are the same, remove the year range
                         # and replace it with the current year
                         line = line.replace(line[paren_index:cpright_index], current_year)
-                    print(line.rstrip().replace("\r\n", "\n"))
+                    print(line.rstrip())
             else:
-                print(line.rstrip().replace("\r\n", "\n"))
+                print(line.rstrip())
 
     fileinput.close()
+
+    replace_windows_line_endings(repo_license_loc)
 
     # If the year changed, print a message that the LICENSE file was changed
     if not check_same_content(save_repo_license, repo_license_loc):

--- a/src/ansys/pre_commit_hooks/add_license_headers.py
+++ b/src/ansys/pre_commit_hooks/add_license_headers.py
@@ -583,16 +583,16 @@ def update_license_file(arg_dict):
                     else:
                         # Replace the existing copyright years with the new year_range
                         line = line.replace(line[paren_index:cpright_index], year_range)
-                    print(line.rstrip())
+                    print(line.rstrip().replace("\r\n", "\n"))
                 else:
                     if "-" in line:
                         # If there is a year range in the existing LICENSE file, but the
                         # start_year and current_year are the same, remove the year range
                         # and replace it with the current year
                         line = line.replace(line[paren_index:cpright_index], current_year)
-                    print(line.rstrip())
+                    print(line.rstrip().replace("\r\n", "\n"))
             else:
-                print(line.rstrip())
+                print(line.rstrip().replace("\r\n", "\n"))
 
     fileinput.close()
 

--- a/tests/test_reuse.py
+++ b/tests/test_reuse.py
@@ -584,6 +584,12 @@ def check_license_year(license_file, copyright, start_year, current_year):
         return
 
 
+def check_line_endings(license_file):
+    with open(license_file, "rb") as file:
+        content = file.read()
+        assert b"\r\n" not in content
+
+
 @pytest.mark.license_headers
 def test_license_year_update(tmp_path: pytest.TempPathFactory):
     """Tests if the year in the license header is updated."""
@@ -626,6 +632,7 @@ def test_license_year_update(tmp_path: pytest.TempPathFactory):
         check_license_year(
             tmp_license, values["copyright"], values["start_year"], values["current_year"]
         )
+        check_line_endings(tmp_license)
 
     os.chdir(REPO_PATH)
 


### PR DESCRIPTION
Check if the license file has Windows line endings and if so, replace them with Unix line endings

Closes #232 