### PR TITLE
CHORE: Add hacktoberfest labels

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -25,3 +25,11 @@
 - name: release
   description: Anything related to an incoming release
   color: ffffff
+
+- name: hacktoberfest
+  description: Hacktoberfest related
+  color: 62ca50
+
+- name: hacktoberfest-accepted
+  description: Hacktoberfest accepted contribution
+  color: 62ca50

--- a/doc/changelog.d/241.maintenance.md
+++ b/doc/changelog.d/241.maintenance.md
@@ -1,0 +1,1 @@
+CHORE: Add hacktoberfest labels


### PR DESCRIPTION
As title says. 

> Note: Adding the `hacktoberfest` label to #125 and #199 failed.