### PR TITLE
fix: Fix Windows developer mode and comment style bugs

### DIFF
--- a/doc/changelog.d/420.fixed.md
+++ b/doc/changelog.d/420.fixed.md
@@ -1,0 +1,1 @@
+Fix Windows developer mode and comment style bugs

--- a/doc/source/getting-started/add-license-headers/issues-limitations.rst
+++ b/doc/source/getting-started/add-license-headers/issues-limitations.rst
@@ -13,3 +13,11 @@ Known issues and limitations
     To request support for an unrecognized file type, open an
     `issue <https://github.com/ansys/pre-commit-hooks/issues>`_ in the ``ansys/pre-commit-hooks``
     repository.
+
+.. dropdown:: I am getting a "OSError: [WinError 1314] A required privilege is not held by the client" error when running the hook on Windows
+    :animate: fade-in-slide-down
+
+    This issue is fixed in version 0.7.1 and later. If you are using an older version of the hook
+    and do not want to upgrade, you can fix this issue by enabling Developer Mode on Windows. To
+    enable Developer Mode, see Microsoft's `Settings for developers <https://learn.microsoft.com/en-us/windows/advanced-settings/developer-mode>`_
+    documentation.

--- a/src/ansys/pre_commit_hooks/add_license_headers.py
+++ b/src/ansys/pre_commit_hooks/add_license_headers.py
@@ -340,7 +340,13 @@ def mkdirs_and_link(
         dest.unlink()
 
     # Make symbolic links to files within the assets folder
-    dest.symlink_to(src)
+    # Fall back to copying if symlinks are not permitted (e.g. Windows without Developer Mode)
+    try:
+        dest.symlink_to(src)
+    except OSError:
+        import shutil
+
+        shutil.copy2(src, dest)
 
 
 def _has_current_header(file_path: str, copyright: list, years: str) -> bool:
@@ -686,12 +692,17 @@ def add_header(
     )
 
     # Add or update the header in the file with the REUSE information.
+    comment_style = get_comment_style(file)
+    if comment_style is None:
+        print(f"Skipping {file}: no comment style found for this file type.", file=out)
+        return
+
     add_header_to_file(
         path=file,
         reuse_info=reuse_info,
         template=template,
         template_is_commented=commented,
-        style=f"{get_comment_style(file).SHORTHAND}",
+        style=f"{comment_style.SHORTHAND}",
         merge_copyrights=True,
         out=out,
     )

--- a/tests/test_add_license_headers.py
+++ b/tests/test_add_license_headers.py
@@ -497,6 +497,79 @@ def test_copy_assets(tmp_path: pytest.TempPathFactory):
 
 
 @pytest.mark.add_license_headers
+def test_mkdirs_and_link_creates_symlink(tmp_path):
+    """Test that mkdirs_and_link creates a symlink when permissions allow."""
+    src_dir = tmp_path / "hook_assets"
+    src_dir.mkdir()
+    src_file = src_dir / "ansys.jinja2"
+    src_file.write_text("template content")
+
+    dest_dir = tmp_path / "repo" / ".reuse" / "templates"
+    asset_dir = str(dest_dir)
+
+    hook.mkdirs_and_link(asset_dir, str(src_dir), str(dest_dir), "ansys.jinja2")
+
+    dest_file = dest_dir / "ansys.jinja2"
+    assert dest_file.exists()
+    assert dest_file.read_text() == "template content"
+
+
+@pytest.mark.add_license_headers
+def test_mkdirs_and_link_fallback_copy_on_oserror(tmp_path, monkeypatch):
+    """Test that mkdirs_and_link falls back to copying when symlink raises OSError."""
+    src_dir = tmp_path / "hook_assets"
+    src_dir.mkdir()
+    src_file = src_dir / "ansys.jinja2"
+    src_file.write_text("template content")
+
+    dest_dir = tmp_path / "repo" / ".reuse" / "templates"
+    asset_dir = str(dest_dir)
+
+    # Simulate Windows symlink privilege error
+    monkeypatch.setattr(
+        Path,
+        "symlink_to",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            OSError(1314, "A required privilege is not held by the client")
+        ),
+    )
+
+    hook.mkdirs_and_link(asset_dir, str(src_dir), str(dest_dir), "ansys.jinja2")
+
+    dest_file = dest_dir / "ansys.jinja2"
+    assert dest_file.exists()
+    assert not dest_file.is_symlink()
+    assert dest_file.read_text() == "template content"
+
+
+@pytest.mark.add_license_headers
+def test_mkdirs_and_link_skips_existing_symlink(tmp_path):
+    """Test that mkdirs_and_link skips creation when symlink points to the correct source."""
+    src_dir = tmp_path / "hook_assets"
+    src_dir.mkdir()
+    src_file = src_dir / "ansys.jinja2"
+    src_file.write_text("template content")
+
+    dest_dir = tmp_path / "repo" / ".reuse" / "templates"
+    dest_dir.mkdir(parents=True)
+    dest_file = dest_dir / "ansys.jinja2"
+
+    try:
+        dest_file.symlink_to(src_file)
+    except OSError:
+        pytest.skip("Symlinks not supported on this platform/environment")
+
+    mtime_before = src_file.stat().st_mtime
+
+    hook.mkdirs_and_link(str(dest_dir), str(src_dir), str(dest_dir), "ansys.jinja2")
+
+    # File should still exist and be unchanged
+    assert dest_file.is_symlink()
+    assert dest_file.read_text() == "template content"
+    assert src_file.stat().st_mtime == mtime_before
+
+
+@pytest.mark.add_license_headers
 def test_bad_chars(tmp_path: pytest.TempPathFactory):
     # Set template and license names
     template_name = "ansys.jinja2"

--- a/tests/test_add_license_headers.py
+++ b/tests/test_add_license_headers.py
@@ -22,6 +22,7 @@
 
 import argparse
 from datetime import date as dt
+import io
 import os
 from pathlib import Path
 import shutil
@@ -567,6 +568,35 @@ def test_mkdirs_and_link_skips_existing_symlink(tmp_path):
     assert dest_file.is_symlink()
     assert dest_file.read_text() == "template content"
     assert src_file.stat().st_mtime == mtime_before
+
+
+@pytest.mark.add_license_headers
+def test_add_header_skips_unknown_comment_style(tmp_path, monkeypatch):
+    """Test add_header skips files when no comment style can be inferred."""
+    test_file = tmp_path / "unknown.ext"
+    test_file.write_text("content\n", encoding="utf-8")
+
+    called = {"add_header_to_file": False}
+
+    def _fake_add_header_to_file(**_kwargs):
+        called["add_header_to_file"] = True
+
+    monkeypatch.setattr("reuse.cli.annotate.get_comment_style", lambda _path: None)
+    monkeypatch.setattr("reuse.cli.annotate.add_header_to_file", _fake_add_header_to_file)
+
+    out = io.StringIO()
+    hook.add_header(
+        [DEFAULT_COPYRIGHT],
+        ["MIT"],
+        f"{dt.today().year}",
+        str(test_file),
+        "ansys.jinja2",
+        True,
+        out,
+    )
+
+    assert not called["add_header_to_file"]
+    assert "Skipping" in out.getvalue()
 
 
 @pytest.mark.add_license_headers


### PR DESCRIPTION
- Fixed `os.symlink` error for the following Windows error: `OSError: [WinError 1314] A required privilege is not held by the client`. Closes #401 
- Fixed the bug where the comment style of the file can't be retrieved due to unsupported file type. If the file type is unsupported, it prints a message and returns