### PR TITLE
fix: Fix duplicate printed lines when updating license header

### DIFF
--- a/doc/changelog.d/422.fixed.md
+++ b/doc/changelog.d/422.fixed.md
@@ -1,0 +1,1 @@
+Fix duplicate printed lines when updating license header

--- a/src/ansys/pre_commit_hooks/add_license_headers.py
+++ b/src/ansys/pre_commit_hooks/add_license_headers.py
@@ -29,6 +29,7 @@ A license header consists of the Ansys copyright statement and licensing informa
 import argparse
 from datetime import date as dt
 import filecmp
+import io
 from pathlib import Path
 import re
 import shutil
@@ -507,7 +508,6 @@ def non_recursive_file_check(
                 before_hook = NamedTemporaryFile(mode="w", delete=False).name
                 shutil.copyfile(file, before_hook)
                 _strip_reuse_header(file)
-                with NamedTemporaryFile(mode="w", delete=True) as tmp:
                 add_header(copyright, license, years, file, template, commented, io.StringIO())
                 if not check_same_content(before_hook, file):
                     changed_headers = 1

--- a/src/ansys/pre_commit_hooks/add_license_headers.py
+++ b/src/ansys/pre_commit_hooks/add_license_headers.py
@@ -674,7 +674,7 @@ def add_header(
         The template to use for the license header. For example, "ansys.jinja2".
     commented: bool
         Whether the template is commented or not.
-    tmp: Union[NamedTemporaryFile, IO[str]]
+    out: Union[NamedTemporaryFile, IO[str]]
         Temporary file to capture the stdout of the add_header_to_file() function or ``sys.stdout``.
     """
     from reuse.cli.annotate import add_header_to_file, get_comment_style, get_reuse_info

--- a/src/ansys/pre_commit_hooks/add_license_headers.py
+++ b/src/ansys/pre_commit_hooks/add_license_headers.py
@@ -507,7 +507,8 @@ def non_recursive_file_check(
                 before_hook = NamedTemporaryFile(mode="w", delete=False).name
                 shutil.copyfile(file, before_hook)
                 _strip_reuse_header(file)
-                add_header(copyright, license, years, file, template, commented, sys.stdout)
+                with NamedTemporaryFile(mode="w", delete=True) as tmp:
+                    add_header(copyright, license, years, file, template, commented, tmp)
                 if not check_same_content(before_hook, file):
                     changed_headers = 1
                     print(f"Successfully changed header of {file}")

--- a/src/ansys/pre_commit_hooks/add_license_headers.py
+++ b/src/ansys/pre_commit_hooks/add_license_headers.py
@@ -508,7 +508,7 @@ def non_recursive_file_check(
                 shutil.copyfile(file, before_hook)
                 _strip_reuse_header(file)
                 with NamedTemporaryFile(mode="w", delete=True) as tmp:
-                    add_header(copyright, license, years, file, template, commented, tmp)
+                add_header(copyright, license, years, file, template, commented, io.StringIO())
                 if not check_same_content(before_hook, file):
                     changed_headers = 1
                     print(f"Successfully changed header of {file}")

--- a/tests/test_add_license_headers.py
+++ b/tests/test_add_license_headers.py
@@ -951,6 +951,46 @@ def test_mit_header_replaced_with_apache(tmp_path: pytest.TempPathFactory):
 
 
 @pytest.mark.add_license_headers
+def test_no_duplicate_prints_on_license_switch(
+    tmp_path: pytest.TempPathFactory, capsys: pytest.CaptureFixture
+):
+    """Test that switching from MIT to Apache-2.0 prints each changed file exactly once."""
+    template_name = "ansys.jinja2"
+    license_name = "Apache-2.0.txt"
+    template_path = Path(REPO_PATH) / ".reuse" / "templates" / template_name
+    license_path = (
+        Path(REPO_PATH)
+        / "src"
+        / "ansys"
+        / "pre_commit_hooks"
+        / "assets"
+        / "LICENSES"
+        / license_name
+    )
+
+    repo, tmp_file = set_up_repo(tmp_path, template_path, template_name, license_path, license_name)
+
+    # First run: add the MIT header
+    add_argv_run(repo, tmp_file, [tmp_file])
+    repo.index.add([tmp_file])
+    capsys.readouterr()  # discard output from the MIT-header run
+
+    # Second run: switch to Apache-2.0 — triggers the license-switch branch
+    add_argv_run(repo, tmp_file, [tmp_file, "--custom_license=Apache-2.0"])
+
+    captured = capsys.readouterr()
+    file_lines = [
+        line for line in captured.out.splitlines() if "Successfully changed header" in line
+    ]
+    assert len(file_lines) == 1, (
+        f"Expected 'Successfully changed header' to appear exactly once, "
+        f"but got {len(file_lines)} time(s):\n{captured.out}"
+    )
+
+    os.chdir(REPO_PATH)
+
+
+@pytest.mark.add_license_headers
 def test_mit_license_file_replaced_with_apache(tmp_path: pytest.TempPathFactory):
     """Test that LICENSE file is regenerated as Apache-2.0 when it's the custom license."""
     template_name = "ansys.jinja2"


### PR DESCRIPTION
In v0.7.1, the "Successfully changed {file}" lines are printed twice when a file is changed. This fixes that issue