### PR TITLE
docs: ignore linkcheck on repository links

### DIFF
--- a/doc/changelog.d/425.documentation.md
+++ b/doc/changelog.d/425.documentation.md
@@ -1,0 +1,1 @@
+Ignore linkcheck on repository links

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -106,6 +106,7 @@ master_doc = "index"
 # Ignore links
 linkcheck_exclude_documents = ["changelog"]
 linkcheck_ignore = [
+    r"https://github.com/ansys/pre-commit-hooks/.*".
     "https://opensource.org/licenses/MIT",
 ]
 

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -104,6 +104,7 @@ source_suffix = {".rst": "restructuredtext"}
 master_doc = "index"
 
 # Ignore links
+linkcheck_exclude_documents = ["changelog"]
 linkcheck_ignore = [
     "https://opensource.org/licenses/MIT",
 ]

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -106,7 +106,7 @@ master_doc = "index"
 # Ignore links
 linkcheck_exclude_documents = ["changelog"]
 linkcheck_ignore = [
-    r"https://github.com/ansys/pre-commit-hooks/.*".
+    r"https://github.com/ansys/pre-commit-hooks/.*",
     "https://opensource.org/licenses/MIT",
 ]
 


### PR DESCRIPTION
We shouldn't check the PR links on the changelog... this can get extremely busy and useless in the longrun. All PRs should exist since they point to content inside the repository.