### PR TITLE
fix: anchor license year update to copyright line

### DIFF
--- a/doc/changelog.d/429.fixed.md
+++ b/doc/changelog.d/429.fixed.md
@@ -1,0 +1,1 @@
+Anchor license year update to copyright line

--- a/src/ansys/pre_commit_hooks/add_license_headers.py
+++ b/src/ansys/pre_commit_hooks/add_license_headers.py
@@ -202,22 +202,23 @@ def update_license_file(
         template_parent_dir = hook_loc / "assets" / "LICENSES"
         generate_license_file(template_parent_dir, year_span, repo_license_path, license)
     else:
-        # The year regex to match the year or year range in the LICENSE file
-        year_regex = r"(\d{4}) - (\d{4})|\d{4}"
-
         content = existing_content
-        # Get the first instance of the year range, either one year or a range of years
-        year_range_match = re.search(year_regex, content)
-        # Get the group from the year_range_match
-        year_range = year_range_match.group()
+        # Match the year (or year range) specifically in the Copyright line.
+        # Searching for the first year in the file is incorrect for licenses like
+        # Apache-2.0 whose boilerplate contains "January 2004" before the copyright
+        # notice, which would otherwise be overwritten with the current year.
+        copyright_year_regex = r"(Copyright(?:\s+\(c\))?\s+)((?:\d{4}\s+-\s+)?\d{4})"
+        year_range_match = re.search(copyright_year_regex, content)
 
-        # Replace the current year span with the updated year span
-        if year_range != year_span:
-            # Update the year span in the LICENSE file. "1" is the max number of replacements
-            content = re.sub(year_regex, year_span, content, 1)
+        if year_range_match:
+            year_range = year_range_match.group(2)
 
-            with repo_license_path.open(encoding="utf-8", newline="", mode="w") as file:
-                file.write(content)
+            # Replace the current year span with the updated year span
+            if year_range != year_span:
+                content = re.sub(copyright_year_regex, rf"\g<1>{year_span}", content, 1)
+
+                with repo_license_path.open(encoding="utf-8", newline="", mode="w") as file:
+                    file.write(content)
 
     # If the file changed, print a message that the LICENSE file was changed
     if not check_same_content(temp_file, repo_license_path):

--- a/src/ansys/pre_commit_hooks/add_license_headers.py
+++ b/src/ansys/pre_commit_hooks/add_license_headers.py
@@ -211,10 +211,12 @@ def update_license_file(
         year_range_match = re.search(copyright_year_regex, content)
 
         if year_range_match:
+            # Get the group from the year_range_match
             year_range = year_range_match.group(2)
 
             # Replace the current year span with the updated year span
             if year_range != year_span:
+                # Update the year span in the LICENSE file. "1" is the max number of replacements
                 content = re.sub(copyright_year_regex, rf"\g<1>{year_span}", content, 1)
 
                 with repo_license_path.open(encoding="utf-8", newline="", mode="w") as file:

--- a/src/ansys/pre_commit_hooks/add_license_headers.py
+++ b/src/ansys/pre_commit_hooks/add_license_headers.py
@@ -221,6 +221,12 @@ def update_license_file(
 
                 with repo_license_path.open(encoding="utf-8", newline="", mode="w") as file:
                     file.write(content)
+        else:
+            # No year found in the Copyright line (e.g. "Copyright [yyyy]" placeholder
+            # in a stock Apache-2.0 LICENSE). Regenerate the file from the template.
+            hook_loc = Path(__file__).parent.resolve()
+            template_parent_dir = hook_loc / "assets" / "LICENSES"
+            generate_license_file(template_parent_dir, year_span, repo_license_path, license)
 
     # If the file changed, print a message that the LICENSE file was changed
     if not check_same_content(temp_file, repo_license_path):
@@ -961,7 +967,7 @@ def main():
         "copyright": args.custom_copyright,
         "template": args.custom_template,
         "license": args.custom_license,
-        "start_year": args.start_year,
+        "start_year": int(args.start_year),
         "current_year": dt.today().year,
         "git_repo": git_repo,
     }

--- a/tests/test_add_license_headers.py
+++ b/tests/test_add_license_headers.py
@@ -1032,6 +1032,34 @@ def test_mit_license_file_replaced_with_apache(tmp_path: pytest.TempPathFactory)
 
 
 @pytest.mark.add_license_headers
+def test_apache_license_year_update_preserves_boilerplate(tmp_path):
+    """Test that updating the year in an Apache-2.0 LICENSE does not corrupt the boilerplate.
+
+    Regression test: the 'January 2004' text in the Apache boilerplate header must not
+    be replaced with the current year when the copyright year is updated.
+    """
+    hook_loc = Path(REPO_PATH) / "src" / "ansys" / "pre_commit_hooks"
+    template_dir = hook_loc / "assets" / "LICENSES"
+    license_file = tmp_path / "LICENSE"
+
+    # Generate an Apache-2.0 LICENSE file with a fixed start year
+    hook.generate_license_file(template_dir, "2023", license_file, "Apache-2.0")
+
+    initial_content = license_file.read_text(encoding="utf-8")
+    assert "January 2004" in initial_content
+    assert "Copyright 2023 ANSYS" in initial_content
+
+    # Simulate a year-span update (e.g., a new calendar year)
+    hook.update_license_file(license_file, "2023 - 2026", "Apache-2.0")
+
+    updated_content = license_file.read_text(encoding="utf-8")
+    assert "January 2004" in updated_content, (
+        "The Apache boilerplate 'January 2004' must not be overwritten by the year update"
+    )
+    assert "Copyright 2023 - 2026 ANSYS" in updated_content
+
+
+@pytest.mark.add_license_headers
 def test_line_endings(tmp_path: pytest.TempPathFactory):
     """Test line endings remain the same before and after running the hook."""
     # List of files to be git added

--- a/tests/test_add_license_headers.py
+++ b/tests/test_add_license_headers.py
@@ -1053,9 +1053,9 @@ def test_apache_license_year_update_preserves_boilerplate(tmp_path):
     hook.update_license_file(license_file, "2023 - 2026", "Apache-2.0")
 
     updated_content = license_file.read_text(encoding="utf-8")
-    assert "January 2004" in updated_content, (
-        "The Apache boilerplate 'January 2004' must not be overwritten by the year update"
-    )
+    assert (
+        "January 2004" in updated_content
+    ), "The Apache boilerplate 'January 2004' must not be overwritten by the year update"
     assert "Copyright 2023 - 2026 ANSYS" in updated_content
 
 


### PR DESCRIPTION
To prevent Apache-2.0 boilerplate corruption
fix #428 
