### PR TITLE
fix: whitelist python-debian

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -147,7 +147,7 @@ jobs:
     name: "Deploy development documentation"
     runs-on: ubuntu-latest
     needs: [build-library]
-    if: github.event_name == 'push' && !contains(github.ref, 'refs/tags')
+    if: github.ref == 'refs/heads/main'
     permissions:
       contents: write  # Needed to write to documentation and push to gh-pages branch
     steps:

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -101,7 +101,7 @@ jobs:
           # This dependency is GPL 2 or later licensed, but is only used for parsing Debian control
           # files and is not distributed with the library, so we can safely ignore it in our
           # license checks
-          whitelist-license-check: "python-debian"  
+          whitelist-license-check: "python-debian"
 
   tests:
     name: "Tests"

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -98,6 +98,10 @@ jobs:
           library-name: ${{ env.LIBRARY_NAME }}
           operating-system: ${{ matrix.os }}
           python-version: ${{ matrix.python-version }}
+          # This dependency is GPL 2 or later licensed, but is only used for parsing Debian control
+          # files and is not distributed with the library, so we can safely ignore it in our
+          # license checks
+          whitelist-license-check: "python-debian"  
 
   tests:
     name: "Tests"

--- a/doc/changelog.d/442.fixed.md
+++ b/doc/changelog.d/442.fixed.md
@@ -1,0 +1,1 @@
+Whitelist python-debian


### PR DESCRIPTION
This issue was silently ignored up until recently, when the package changed its license sharing information in the project's metadata. We need to merge this one first before #441 