### PR TITLE
build(deps): bump GitPython from 3.1.54 to 3.1.58

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
     url="https://github.com/ansys/pre-commit-hooks",
     python_requires=">=3.10,<4",
     install_requires=[
-        "GitPython==3.1.54",
+        "GitPython==3.1.57",
         "importlib-metadata==9.0.0",
         "Jinja2==3.1.6",
         "reuse==6.2.0",

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
     url="https://github.com/ansys/pre-commit-hooks",
     python_requires=">=3.10,<4",
     install_requires=[
-        "GitPython==3.1.57",
+        "GitPython==3.1.58",
         "importlib-metadata==9.0.0",
         "Jinja2==3.1.6",
         "reuse==6.2.0",


### PR DESCRIPTION
Bumps GitPython from 3.1.54 to 3.1.57.

**Cleared advisories:**
- GHSA-3f7w-8rr8-f37f — Unguarded git option forwarding in `IndexFile.checkout()` and `TagReference.create()` enables arbitrary file overwrite and arbitrary file read (HIGH)
- GHSA-p538-c434-8v24
- GHSA-94p4-4cq8-9g67

**Verification:** `pip-audit --no-deps -r setup.py` reports 3 vulnerabilities before patch; 0 after patch.

Diff: single line in `setup.py` (install_requires pin).

Release notes: https://github.com/gitpython-developers/GitPython/blob/main/CHANGELOG.md